### PR TITLE
Restart session after a number of prints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   Expose `Template.html_concat` as potentially useful helper.
 - Reset navigation history after each print job to avoid leaking information.
 - Create new empty browser context for each target (similar to incognito tab).
+- Restart browser target after a maximum number of PDFs have been printed to avoid memory bloat.
 
 ### Changed
 

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -29,7 +29,9 @@ defmodule ChromicPDF do
 
   See `ChromicPDF.print_to_pdf/2` and `ChromicPDF.convert_to_pdfa/2`.
 
-  ### Options
+  ## Options
+
+  ### Worker pools
 
   ChromicPDF spawns two worker pools, the session pool and the ghostscript pool. By default, it
   will create 5 workers with no overflow. To change these options, you can pass configuration to
@@ -49,6 +51,16 @@ defmodule ChromicPDF do
             max_overflow: 2
           ]
         ]
+      end
+
+  ### Automatic session restarts to avoid memory drain
+
+  By default, ChromicPDF will restart sessions within the Chrome process after 1000 operations.
+  This helps to prevent infinite growth in Chrome's overall memory consumption. This "max age" of
+  a session can be configured by setting the `:max_session_uses` option.
+
+      defp chromic_pdf_opts do
+        [max_session_uses: 1000]
       end
 
   ## Security Considerations

--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -19,11 +19,6 @@ defmodule ChromicPDF.Browser do
     GenServer.start_link(__MODULE__, args, name: name)
   end
 
-  @spec run_protocol(browser(), module(), keyword()) :: {:ok, any()}
-  def run_protocol(browser, protocol_mod, opts) do
-    genserver_call(browser, {:run_protocol, protocol_mod.new(opts)})
-  end
-
   @spec run_protocol(browser(), Protocol.t()) :: {:ok, any()} | {:error, term()}
   def run_protocol(browser, %Protocol{} = protocol) do
     genserver_call(browser, {:run_protocol, protocol})

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -11,7 +11,7 @@ defmodule ChromicPDF.ProtocolMacros do
       unquote(block)
 
       @spec new(keyword()) :: Protocol.t()
-      def new(opts) do
+      def new(opts \\ []) do
         Protocol.new(
           build_steps(opts),
           Enum.into(opts, %{})

--- a/lib/chromic_pdf/pdf/protocols/close_target.ex
+++ b/lib/chromic_pdf/pdf/protocols/close_target.ex
@@ -1,0 +1,11 @@
+defmodule ChromicPDF.CloseTarget do
+  @moduledoc false
+
+  import ChromicPDF.ProtocolMacros
+
+  steps do
+    call(:close_target, "Target.closeTarget", [:targetId], %{})
+    await_response(:target_closed, ["success"])
+    reply("success")
+  end
+end

--- a/lib/chromic_pdf/pdf/protocols/create_target.ex
+++ b/lib/chromic_pdf/pdf/protocols/create_target.ex
@@ -1,0 +1,15 @@
+defmodule ChromicPDF.CreateTarget do
+  @moduledoc false
+
+  import ChromicPDF.ProtocolMacros
+
+  steps do
+    call(:create_browser_context, "Target.createBrowserContext", [], %{"disposeOnDetach" => true})
+    await_response(:browser_context_created, ["browserContextId"])
+
+    call(:create_target, "Target.createTarget", ["browserContextId"], %{"url" => "about:blank"})
+    await_response(:target_created, ["targetId"])
+
+    reply("targetId")
+  end
+end

--- a/lib/chromic_pdf/pdf/protocols/spawn_session.ex
+++ b/lib/chromic_pdf/pdf/protocols/spawn_session.ex
@@ -6,18 +6,12 @@ defmodule ChromicPDF.SpawnSession do
   @version Mix.Project.config()[:version]
 
   steps do
-    call(:create_browser_context, "Target.createBrowserContext", [], %{"disposeOnDetach" => true})
-    await_response(:browser_context_created, ["browserContextId"])
-
-    call(:create_target, "Target.createTarget", ["browserContextId"], %{"url" => "about:blank"})
-    await_response(:target_created, ["targetId"])
-
-    call(:attach, "Target.attachToTarget", ["targetId"], %{"flatten" => true})
+    call(:attach, "Target.attachToTarget", [:targetId], %{"flatten" => true})
 
     await_notification(
       :attached,
       "Target.attachedToTarget",
-      [{["targetInfo", "targetId"], "targetId"}],
+      [{["targetInfo", "targetId"], :targetId}],
       ["sessionId"]
     )
 

--- a/test/integration/session_restart_test.exs
+++ b/test/integration/session_restart_test.exs
@@ -1,0 +1,53 @@
+defmodule ChromicPDF.SessionRestartTest do
+  use ExUnit.Case, async: false
+
+  @ps_cmd :"ps ax | grep -v grep | grep -i Chrom"
+  @wait_ms 500
+
+  # This gets all pids of Chrome, chromium*, chrome-browser, or whatever Chrome process on the
+  # system and reads their pids from "ps" output. Please don't mess with the "ps ax" line above,
+  # ps's options are quite cumbersome to get right in a platform-independent way.
+  defp chrome_pids do
+    @ps_cmd
+    |> :os.cmd()
+    |> to_string()
+    |> String.trim()
+    |> String.split("\n")
+    |> Enum.map(fn x -> Regex.named_captures(~r/[^\d]*(?<pid>[\d]+)/, x)["pid"] end)
+  end
+
+  defp print_and_wait do
+    {:ok, _blob} = ChromicPDF.print_to_pdf({:html, ""})
+    :timer.sleep(@wait_ms)
+  end
+
+  describe "sessions automatically restart after a number of operations" do
+    setup do
+      start_supervised!({ChromicPDF, max_session_uses: 2})
+      :timer.sleep(@wait_ms)
+      :ok
+    end
+
+    test "session restart spawns a new session process" do
+      pids0 = chrome_pids()
+
+      # We have at least 1 BEAM process, 1 Chrome process, and one target process.
+      assert length(pids0) >= 3
+
+      print_and_wait()
+      pids1 = chrome_pids()
+
+      # After the first print operation, the pids should remain exactly the same.
+      assert pids0 == pids1
+
+      print_and_wait()
+      pids2 = chrome_pids()
+
+      # After the second print operation, we expect the Session to have restarted its target
+      # process, so exactly one pid should have changed.
+      assert length(pids1) == length(pids2)
+      assert assert(length(pids1 -- pids2)) == 1
+      assert assert(length(pids2 -- pids1)) == 1
+    end
+  end
+end


### PR DESCRIPTION
* This PR adds logic to `Session` that makes it automatically close and re-create its Target
* This in turn causes Chrome to create a new OS process (and kill the old one), keeping its overall memory footprint in check.