### PR TITLE
Change Template options around.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 - Removed the `:width` and `:height` options from `Template.styles/1` and
   `Template.source_and_options/1` as it turns out that Chrome does not pay attention to `@page`
-  dimensions and instead still sets the size of the produced PDF to US letter. Since I could not
-  figure out a way to set the PDF size besides using the `paperWidth` and `paperHeight` options,
-  I resided to moving to a `:size` option instead that accepts names like `:a4`, `:letter`, and
-  tuples of `{<width>, <height>}` in inches. These are then passed to `paperWidth` and
-  `paperHeight`.
+  dimensions and instead still sets the size of the produced PDF to US letter. Since it does not
+  seem possible to the PDF size in Chrome headless besides using the `paperWidth` and
+  `paperHeight` options, modved to a `:size` option instead that accepts names like `:a4`,
+  `:us_letter`, and tuples of `{<width>, <height>}` in inches. These are then passed to
+  `paperWidth` and `paperHeight`.
 - Ditched the `preferCssPageSize` option from `Template.source_and_options/1` as it did not seem
   to have any effect. See above.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   `Template.source_and_options/1` as it turns out that Chrome does not pay attention to `@page`
   dimensions and instead still sets the size of the produced PDF to US letter. Since it does not
   seem possible to the PDF size in Chrome headless besides using the `paperWidth` and
-  `paperHeight` options, modved to a `:size` option instead that accepts names like `:a4`,
+  `paperHeight` options, moved to a `:size` option instead that accepts names like `:a4`,
   `:us_letter`, and tuples of `{<width>, <height>}` in inches. These are then passed to
   `paperWidth` and `paperHeight`.
 - Ditched the `preferCssPageSize` option from `Template.source_and_options/1` as it did not seem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## Unreleased
 
+### Changed
+
+- Removed the `:width` and `:height` options from `Template.styles/1` and
+  `Template.source_and_options/1` as it turns out that Chrome does not pay attention to `@page`
+  dimensions and instead still sets the size of the produced PDF to US letter. Since I could not
+  figure out a way to set the PDF size besides using the `paperWidth` and `paperHeight` options,
+  I resided to moving to a `:size` option instead that accepts names like `:a4`, `:letter`, and
+  tuples of `{<width>, <height>}` in inches. These are then passed to `paperWidth` and
+  `paperHeight`.
+- Ditched the `preferCssPageSize` option from `Template.source_and_options/1` as it did not seem
+  to have any effect. See above.
+
+### Added
+
+- Added `zoom: 0.75` to both `#header` and `#footer` in the template as this seems to be exactly
+  what is needed to reverse the viewport scaling that Chrome uses on them by default. With this,
+  headers & footers and the content can use the same CSS styles.
+- Included `-webkit-print-color-adjust: exact` rule to template so `background-color` rules are
+  enabled by default.
+
 ### Fixed
 
 - Make `print_to_pdfa/2` actually accept `source_and_options()` map from `Template`.

--- a/lib/chromic_pdf/template.ex
+++ b/lib/chromic_pdf/template.ex
@@ -25,7 +25,7 @@ defmodule ChromicPDF.Template do
           | {:header, blob()}
           | {:footer, blob()}
 
-  @type paper_size :: :a4 | :letter | {float(), float()}
+  @type paper_size :: :a4 | :us_letter | {float(), float()}
 
   @type style_option ::
           {:size, paper_size()}
@@ -36,7 +36,7 @@ defmodule ChromicPDF.Template do
 
   @paper_sizes_in_inch %{
     a4: {8.3, 11.7},
-    letter: {8.5, 11.0}
+    us_letter: {8.5, 11.0}
   }
 
   @default_content """
@@ -194,8 +194,8 @@ defmodule ChromicPDF.Template do
 
   ## Options
 
-  * `size` page size, either a standard name (`:a4`, `:letter`) or a
-     `{<width>, <height>}` tuple in inches, default: `:letter`
+  * `size` page size, either a standard name (`:a4`, `:us_letter`) or a
+     `{<width>, <height>}` tuple in inches, default: `:us_letter`
   * `header_height` default: zero
   * `header_font_size` default: 10pt
   * `header_zoom` default: 0.75
@@ -231,7 +231,7 @@ defmodule ChromicPDF.Template do
 
   defp get_paper_size(opts) when is_list(opts) do
     opts
-    |> Keyword.get(:size, :letter)
+    |> Keyword.get(:size, :us_letter)
     |> get_paper_size()
   end
 end

--- a/lib/chromic_pdf/template.ex
+++ b/lib/chromic_pdf/template.ex
@@ -6,6 +6,14 @@ defmodule ChromicPDF.Template do
   set of page sizing options. Using this module is entirely optional, but perhaps can help to
   avoid some common pitfalls arising from the slightly unintuitive and sometimes conflicting
   behaviour of `printToPDF` options and `@page` CSS styles in Chrome.
+
+  One particularly cumbersome detail is that Chrome in headless mode does not correctly interpret
+  the `@page` CSS rule to configure the page dimensions. Resulting PDF files will always be in
+  US-letter format unless configured differently with the `paperWidth` and `paperHeight` options.
+  In my experience, results will be best if the `@page` rule aligns with the values passed to
+  `printToPDF`, which is why these helpers exist to make basic page styling a bit easier.
+
+  For a start, see `source_and_options/1`.
   """
 
   require EEx
@@ -17,13 +25,19 @@ defmodule ChromicPDF.Template do
           | {:header, blob()}
           | {:footer, blob()}
 
+  @type paper_size :: :a4 | :letter | {float(), float()}
+
   @type style_option ::
-          {:width, binary()}
-          | {:height, binary()}
+          {:size, paper_size()}
           | {:header_height, binary()}
           | {:header_font_size, binary()}
           | {:footer_height, binary()}
           | {:footer_font_size, binary()}
+
+  @paper_sizes_in_inch %{
+    a4: {8.3, 11.7},
+    letter: {8.5, 11.0}
+  }
 
   @default_content """
   <style>
@@ -85,8 +99,7 @@ defmodule ChromicPDF.Template do
         content: "<p>Hello</p>",
         header: "<p>header</p>",
         footer: "<p>footer</p>"
-        width: "210mm",
-        height: "297mm",
+        size: :a4,
         header_height: "45mm",
         header_font_size: "20pt",
         footer_height: "40mm"
@@ -95,14 +108,10 @@ defmodule ChromicPDF.Template do
   Content, header, and footer templates should be unwrapped HTML markup (i.e. no `<html>` around
   the content), prefixed with any `<style>` tags that your page needs.
 
-      ChromicPDF.Template.source_and_options(
-        content: \"""
         <style>
           h1 { font-size: 22pt; }
         </style>
         <h1>Hello</h1>
-        \"""
-      )
   """
   @spec source_and_options([content_option() | style_option()]) ::
           ChromicPDF.Processor.source_and_options()
@@ -112,14 +121,17 @@ defmodule ChromicPDF.Template do
     footer = Keyword.get(opts, :footer, "")
     styles = styles(opts)
 
+    {width, height} = get_paper_size(opts)
+
     %{
       source: {:html, html_concat(styles, content)},
       opts: [
         print_to_pdf: %{
-          preferCSSPageSize: true,
           displayHeaderFooter: true,
           headerTemplate: html_concat(styles, header),
-          footerTemplate: html_concat(styles, footer)
+          footerTemplate: html_concat(styles, footer),
+          paperWidth: width,
+          paperHeight: height
         }
       ]
     }
@@ -140,6 +152,10 @@ defmodule ChromicPDF.Template do
 
   @styles """
   <style>
+    * {
+      -webkit-print-color-adjust: <%= @webkit_print_color_adjust %>;
+    }
+
     @page {
       width: <%= @width %>;
       height: <%= @height %>;
@@ -150,15 +166,17 @@ defmodule ChromicPDF.Template do
       padding: 0 !important;
       height: <%= @header_height %>;
       font-size: <%= @header_font_size %>;
+      zoom: <%= @header_zoom %>;
     }
 
     #footer {
       padding: 0 !important;
       height: <%= @footer_height %>;
       font-size: <%= @footer_font_size %>;
+      zoom: <%= @footer_zoom %>;
     }
 
-    body {
+    html, body {
       margin: 0;
       padding: 0;
     }
@@ -171,31 +189,49 @@ defmodule ChromicPDF.Template do
   These base styles will configure page dimensions and header and footer heights. They also
   remove any browser padding and margins from these elements, and set the font-size.
 
-  If you want to use these, make sure to set the `preferCSSPageSize: true` option, or use
-  `source_and_options/1`.
+  Additionally, they set the zoom level of header and footer templates to 0.75 which seems to
+  make them align with the content viewport scaling better.
 
   ## Options
 
-  * `width` page width in any CSS unit, default: 279.4mm / 11 inches (US letter)
-  * `height` default: 215.9mm / 8.5 inches
+  * `size` page size, either a standard name (`:a4`, `:letter`) or a
+     `{<width>, <height>}` tuple in inches, default: `:letter`
   * `header_height` default: zero
   * `header_font_size` default: 10pt
+  * `header_zoom` default: 0.75
   * `footer_height` default: zero
   * `footer_font_size` default: 10pt
+  * `footer_zoom` default: 0.75
+  * `webkit_color_print_adjust` default: "exact"
   """
   @spec styles([style_option()]) :: blob()
   def styles(opts \\ []) do
+    {width, height} = get_paper_size(opts)
+
     assigns = [
-      height: Keyword.get(opts, :height, "215.9mm"),
-      width: Keyword.get(opts, :width, "279.4mm"),
+      width: "#{width}in",
+      height: "#{height}in",
       header_height: Keyword.get(opts, :header_height, "0"),
       header_font_size: Keyword.get(opts, :header_font_size, "10pt"),
       footer_height: Keyword.get(opts, :footer_height, "0"),
-      footer_font_size: Keyword.get(opts, :footer_font_size, "10pt")
+      footer_font_size: Keyword.get(opts, :footer_font_size, "10pt"),
+      header_zoom: Keyword.get(opts, :header_zoom, "0.75"),
+      footer_zoom: Keyword.get(opts, :footer_zoom, "0.75"),
+      webkit_print_color_adjust: Keyword.get(opts, :webkit_print_color_adjust, "exact")
     ]
 
     render_styles(assigns)
   end
 
   EEx.function_from_string(:defp, :render_styles, @styles, [:assigns])
+
+  # Fetches paper size from opts, translates from config or uses given {width, height} tuple.
+  defp get_paper_size(manual) when tuple_size(manual) == 2, do: manual
+  defp get_paper_size(name) when is_atom(name), do: Map.fetch!(@paper_sizes_in_inch, name)
+
+  defp get_paper_size(opts) when is_list(opts) do
+    opts
+    |> Keyword.get(:size, :letter)
+    |> get_paper_size()
+  end
 end

--- a/lib/chromic_pdf/template.ex
+++ b/lib/chromic_pdf/template.ex
@@ -10,7 +10,7 @@ defmodule ChromicPDF.Template do
   One particularly cumbersome detail is that Chrome in headless mode does not correctly interpret
   the `@page` CSS rule to configure the page dimensions. Resulting PDF files will always be in
   US-letter format unless configured differently with the `paperWidth` and `paperHeight` options.
-  In my experience, results will be best if the `@page` rule aligns with the values passed to
+  Experience has shown, that results will be best if the `@page` rule aligns with the values passed to
   `printToPDF`, which is why these helpers exist to make basic page styling a bit easier.
 
   For a start, see `source_and_options/1`.


### PR DESCRIPTION
* Use `paperWidth` and `paperHeight` after all, as `@page` alone does
not seem to be effective.
* Add `zoom` rule to scale header & footer the same as the content.
* Print background colors by default.

|without zoom|with zoom|
|-|-|
|<img width="521" alt="Screenshot 2020-07-10 at 09 40 07" src="https://user-images.githubusercontent.com/96114/87129452-a30ff580-c291-11ea-895c-e76aded1ac20.png">|<img width="541" alt="Screenshot 2020-07-10 at 09 40 28" src="https://user-images.githubusercontent.com/96114/87129454-a4d9b900-c291-11ea-910a-bd0c3d956a61.png">|

<details>
  <summary>Test code for above</summary>

```
defmodule ChromicPDF.Test do
  def test do
    styles = """
    <style>
      .test {
        margin-top: 1mm;
        height: 18mm;
        width: 30mm;
        background-color: green;
      }
    </style>
    """

    html = [styles, ~s(<div class="test"></div>)]

    [
      content: html,
      header: html,
      footer: html,
      header_height: "20mm",
      footer_height: "20mm",
      size: :a4
    ]
    |> ChromicPDF.Template.source_and_options()
    |> ChromicPDF.print_to_pdf(output: "file.pdf")
  end
end
</details>
