### PR TITLE
Add :eex to extra_applications for Elixir 1.11.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ChromicPdf.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:eex, :logger]
     ]
   end
 


### PR DESCRIPTION
When compiling with Elixir 1.11

```
warning: EEx.Engine.fetch_assign!/2 defined in application :eex is used by the current application but the current application does not directly depend on :eex. To fix this, you must do one of:

  1. If :eex is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :eex is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :eex, you may optionally skip this warning by adding [xref: [exclude: EEx.Engine]] to your "def project" in mix.exs

Found at 28 locations:
  lib/chromic_pdf/template.ex:233: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:237: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:238: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:239: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:244: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:245: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:246: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:251: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:252: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/template.ex:253: ChromicPDF.Template.render_styles/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:10: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:11: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:13: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:14: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:16: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:17: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:19: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:20: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:22: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:23: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:25: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:26: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:28: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:29: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:31: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:32: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:37: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
  lib/chromic_pdf/pdfa/PDFA_def.ps.eex:54: ChromicPDF.GhostscriptWorker.render_pdfa_def_ps/1
```