### PR TITLE
Don't trap exit in Browser.

### DIFF
--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -43,8 +43,6 @@ defmodule ChromicPDF.Browser do
     {:ok, conn_pid} = Connection.start_link(self(), args)
     {:ok, call_count_pid} = CallCount.start_link()
 
-    Process.flag(:trap_exit, true)
-
     dispatch = fn call ->
       call_id = CallCount.bump(call_count_pid)
       Connection.send_msg(conn_pid, JsonRPC.encode(call, call_id))


### PR DESCRIPTION
We either need to handle the `{:EXIT, _pid, :chrome_has_crashed}`
message or alternatively just not trap the exit, which will make the
`Browser` process die alongside its linked `Connection` process.

Addresses #54.

See http://erlang.org/doc/man/erlang.html#process_flag-2