### PR TITLE
Reorganize graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
   `:extra_applications`. ChromicPDF now **requires Elixir >= 1.10** for its use of
   `Application.compile_env/3`.
 
+### Added
+
+- New global option `discard_stderr` allows to enable Chrome's stderr logging which is by default
+  piped to `/dev/null`.
+
+### Fixed
+
+- Graceful shutdown is now actually graceful in that it waits for Chrome to clean up the
+  debugging sessions and close the pipe on its end.
+
 ## [0.5.2] - 2020-07-17
 
 ### Fixed

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -100,6 +100,15 @@ defmodule ChromicPDF do
         [no_sandbox: true]
       end
 
+  ### Enabling Chrome stderr output
+
+  Chrome's stderr logging is silently discarded to not obscure your logfiles. In case you would
+  like to take a peek, add the `discard_stderr: false` option.
+
+      defp chromic_pdf_opts do
+        [discard_stderr: false]
+      end
+
   ## How it works
 
   ### PDF Printing

--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -43,8 +43,6 @@ defmodule ChromicPDF.Browser do
     {:ok, conn_pid} = Connection.start_link(self(), args)
     {:ok, call_count_pid} = CallCount.start_link()
 
-    Process.flag(:trap_exit, true)
-
     dispatch = fn call ->
       call_id = CallCount.bump(call_count_pid)
       Connection.send_msg(conn_pid, JsonRPC.encode(call, call_id))

--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -9,31 +9,36 @@ defmodule ChromicPDF.Browser do
 
   # ------------- API ----------------
 
+  def child_spec(args) do
+    %{
+      id: server_name_from_args(args),
+      start: {ChromicPDF.Browser, :start_link, [args]},
+      shutdown: 5_000
+    }
+  end
+
   @spec start_link(Keyword.t()) :: GenServer.on_start()
   def start_link(args) do
-    name =
-      args
-      |> Keyword.fetch!(:chromic)
-      |> server_name()
-
-    GenServer.start_link(__MODULE__, args, name: name)
+    GenServer.start_link(__MODULE__, args, name: server_name_from_args(args))
   end
 
   @spec run_protocol(browser(), Protocol.t()) :: {:ok, any()} | {:error, term()}
-  def run_protocol(browser, %Protocol{} = protocol) do
-    genserver_call(browser, {:run_protocol, protocol})
+  def run_protocol(chromic, %Protocol{} = protocol) when is_atom(chromic) do
+    GenServer.call(server_name(chromic), {:run_protocol, protocol})
+  end
+
+  def run_protocol(browser, %Protocol{} = protocol) when is_pid(browser) do
+    GenServer.call(browser, {:run_protocol, protocol})
+  end
+
+  defp server_name_from_args(args) do
+    args
+    |> Keyword.fetch!(:chromic)
+    |> server_name()
   end
 
   defp server_name(chromic) do
     Module.concat(chromic, :Browser)
-  end
-
-  defp genserver_call(chromic, msg) when is_atom(chromic) do
-    GenServer.call(server_name(chromic), msg)
-  end
-
-  defp genserver_call(browser, msg) when is_pid(browser) do
-    GenServer.call(browser, msg)
   end
 
   # ----------- Callbacks ------------
@@ -42,6 +47,8 @@ defmodule ChromicPDF.Browser do
   def init(args) do
     {:ok, conn_pid} = Connection.start_link(self(), args)
     {:ok, call_count_pid} = CallCount.start_link()
+
+    Process.flag(:trap_exit, true)
 
     dispatch = fn call ->
       call_id = CallCount.bump(call_count_pid)
@@ -53,8 +60,25 @@ defmodule ChromicPDF.Browser do
   end
 
   @impl GenServer
-  def terminate(_reason, %{dispatch: dispatch}) do
+  def terminate(:shutdown, %{dispatch: dispatch}) do
+    # Graceful shutdown: Dispatch the Browser.close message to Chrome which will cause it to
+    # detach all debugging sessions and close the port.
     dispatch.({"Browser.close", %{}})
+
+    # The Connection process will receive a message about the port termination and forward
+    # this to us. In case Chrome takes longer than the configured supervision shutdown time,
+    # we'll receive a :brutal_kill and exit immediately, so no need for a timeout here.
+    receive do
+      :connection_terminated -> :ok
+    end
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  @impl GenServer
+  def handle_cast(:crash, %{dispatch: dispatch} = state) do
+    dispatch.({"Browser.crash", %{}})
+    {:noreply, state}
   end
 
   @impl GenServer
@@ -73,6 +97,13 @@ defmodule ChromicPDF.Browser do
     msg = JsonRPC.decode(data)
     protocols = Enum.map(protocols, &Protocol.run(&1, msg, dispatch))
     {:noreply, update_protocols(state, protocols)}
+  end
+
+  def handle_info({:connection_terminated, _exit_state}, state) do
+    # If we receive this message in this `handle_info/2` clause, it means that we're not
+    # performing a graceful shutdown right now and Chrome has either crashed or was closed
+    # externally, so let's suicide and let the supervisor restart us.
+    {:stop, :connection_terminated, state}
   end
 
   defp update_protocols(state, protocols) do

--- a/lib/chromic_pdf/pdf/chrome.ex
+++ b/lib/chromic_pdf/pdf/chrome.ex
@@ -2,6 +2,5 @@ defmodule ChromicPDF.Chrome do
   @moduledoc false
 
   @callback spawn(keyword()) :: {:ok, port()}
-  @callback stop(port()) :: :ok
   @callback send_msg(port(), msg :: binary()) :: :ok
 end

--- a/test/unit/chromic_pdf/pdf/connection_test.exs
+++ b/test/unit/chromic_pdf/pdf/connection_test.exs
@@ -36,18 +36,13 @@ defmodule ChromicPDF.ConnectionTest do
   describe "external process supervision" do
     setup [:new_state]
 
-    test "it stops the GenServer when Chrome dies", %{state: state} do
-      assert handle_info({:DOWN, @ref, :port, @port, 127}, state) ==
-               {:stop, :chrome_has_crashed, state}
+    defp assert_connection_terminated() do
+      assert_receive({:connection_terminated, 127})
     end
-  end
 
-  describe "graceful termination" do
-    setup [:new_state]
-
-    test "it stops the spawned Chrome instance when terminated", %{state: state} do
-      expect(ChromeMock, :stop, fn @port -> :ok end)
-      terminate(:normal, state)
+    test "it notifies the parent process when Chrome closes the pipe", %{state: state} do
+      assert handle_info({:DOWN, @ref, :port, @port, 127}, state) == {:noreply, state}
+      assert_connection_terminated()
     end
   end
 


### PR DESCRIPTION
  Reorganize graceful shutdown.

    This changes our (not so-) "graceful" shutdown around to rely on Chrome
    closing itself.

    * Found out about the `nouse_stdio` port setting which is precisely what
      we need in this case (using fd 3 & 4 of an external process for Erlang
      communication!). This enables us to allow users to switch on Chrome
      logging on demand, could be handy if Chrome crashes.
    * Finally understood how `Process.flag(:trap_exit, true)` works in
      combination with `c:GenServer.terminate/2`
    * Hence got rid of the trap in `Connection` (it's only controlling the
      port, no need to trap anything)
    * Instead we forward the `:DOWN` message (from `Port.monitor`) in case
      the Port is closed by Chrome itself up to the Browser.
    * Extended the trap in `Browser` to send the `Browser.close` message and
      then *wait* for a message (bypassing GenServer loop in this case) that
      the port has been closed by the external process, because Chrome in
      fact DOES close the pipe when you send it Browser.close, you only have
      to wait for a bit for it to happen :)
    * Overall much nicer behaviour, doesn't work for the Ctrl+C issue, of
      course; but makes the normal, supervisor-triggered shutdown much more
      graceful.

    Addresses #54.