### PR TITLE
"On Demand" mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Added
 
+- "On Demand" mode allows to start & stop Chrome as needed, much like puppeteer does. This helps
+  in development to prevent leaving behind zombie processes when the BEAM is aborted with Ctrl+C.
 - New global option `discard_stderr` allows to enable Chrome's stderr logging which is by default
   piped to `/dev/null`.
 

--- a/lib/chromic_pdf/api.ex
+++ b/lib/chromic_pdf/api.ex
@@ -4,14 +4,13 @@ defmodule ChromicPDF.API do
   import ChromicPDF.Utils
   alias ChromicPDF.{Browser, CaptureScreenshot, GhostscriptPool, PrintToPDF}
 
-  @type services :: %{
-          browser: pid(),
-          ghostscript_pool: pid()
-        }
-
-  @spec print_to_pdf(services(), ChromicPDF.source() | ChromicPDF.source_and_options(), [
-          ChromicPDF.pdf_option()
-        ]) :: ChromicPDF.return()
+  @spec print_to_pdf(
+          ChromicPDF.Supervisor.services(),
+          ChromicPDF.source() | ChromicPDF.source_and_options(),
+          [
+            ChromicPDF.pdf_option()
+          ]
+        ) :: ChromicPDF.return()
   def print_to_pdf(services, %{source: source, opts: opts}, overrides)
       when tuple_size(source) == 2 and is_list(opts) and is_list(overrides) do
     print_to_pdf(services, source, Keyword.merge(opts, overrides))
@@ -21,7 +20,9 @@ defmodule ChromicPDF.API do
     chrome_export(services, PrintToPDF, source, opts)
   end
 
-  @spec capture_screenshot(services(), ChromicPDF.source(), [ChromicPDF.screenshot_option()]) ::
+  @spec capture_screenshot(ChromicPDF.Supervisor.services(), ChromicPDF.source(), [
+          ChromicPDF.screenshot_option()
+        ]) ::
           ChromicPDF.return()
   def capture_screenshot(services, source, opts) when tuple_size(source) == 2 and is_list(opts) do
     chrome_export(services, CaptureScreenshot, source, opts)
@@ -119,7 +120,9 @@ defmodule ChromicPDF.API do
     end
   end
 
-  @spec convert_to_pdfa(services(), ChromicPDF.path(), [ChromicPDF.pdfa_option()]) ::
+  @spec convert_to_pdfa(ChromicPDF.Supervisor.services(), ChromicPDF.path(), [
+          ChromicPDF.pdfa_option()
+        ]) ::
           ChromicPDF.return()
   def convert_to_pdfa(services, pdf_path, opts) when is_binary(pdf_path) and is_list(opts) do
     with_tmp_dir(fn tmp_dir ->
@@ -127,9 +130,13 @@ defmodule ChromicPDF.API do
     end)
   end
 
-  @spec print_to_pdfa(services(), ChromicPDF.source() | ChromicPDF.source_and_options(), [
-          ChromicPDF.pdf_option() | ChromicPDF.pdfa_option()
-        ]) ::
+  @spec print_to_pdfa(
+          ChromicPDF.Supervisor.services(),
+          ChromicPDF.source() | ChromicPDF.source_and_options(),
+          [
+            ChromicPDF.pdf_option() | ChromicPDF.pdfa_option()
+          ]
+        ) ::
           ChromicPDF.return()
   def print_to_pdfa(services, %{source: source, opts: opts}, overrides)
       when tuple_size(source) == 2 and is_list(opts) and is_list(overrides) do

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule ChromicPdf.MixProject do
     ]
   end
 
+  defp elixirc_paths(:integration), do: ["lib", "test/integration/support"]
   defp elixirc_paths(:test), do: ["lib", "test/unit/support"]
   defp elixirc_paths(_env), do: ["lib"]
 

--- a/test/integration/on_demand_test.exs
+++ b/test/integration/on_demand_test.exs
@@ -1,0 +1,33 @@
+defmodule ChromicPDF.OnDemandTest do
+  use ExUnit.Case, async: false
+  import ChromicPDF.OSHelper
+
+  test "on_demand is disabled by default" do
+    assert_raise RuntimeError, ~r/ChromicPDF isn't running and no :on_demand config/, fn ->
+      ChromicPDF.print_to_pdf({:html, ""})
+    end
+  end
+
+  test "Chrome is spawned eagerly when on_demand is false" do
+    pids_before = chrome_renderer_pids()
+
+    {:ok, _pid} = start_supervised({ChromicPDF, session_pool: [size: 1]})
+
+    pids_now = chrome_renderer_pids()
+    assert length(pids_now) - length(pids_before) == 1
+  end
+
+  test "Chrome is spawned dynamically when on_demand is true" do
+    pids_before = chrome_renderer_pids()
+
+    {:ok, _pid} = start_supervised({ChromicPDF, on_demand: true})
+
+    pids_now = chrome_renderer_pids()
+    assert length(pids_now) == length(pids_before)
+
+    {:ok, _blob} = ChromicPDF.print_to_pdf({:html, ""})
+
+    pids_now = chrome_renderer_pids()
+    assert length(pids_now) == length(pids_before)
+  end
+end

--- a/test/integration/session_restart_test.exs
+++ b/test/integration/session_restart_test.exs
@@ -1,53 +1,30 @@
 defmodule ChromicPDF.SessionRestartTest do
   use ExUnit.Case, async: false
-
-  @ps_cmd :"ps ax | grep -v grep | grep -i Chrom"
-  @wait_ms 500
-
-  # This gets all pids of Chrome, chromium*, chrome-browser, or whatever Chrome process on the
-  # system and reads their pids from "ps" output. Please don't mess with the "ps ax" line above,
-  # ps's options are quite cumbersome to get right in a platform-independent way.
-  defp chrome_pids do
-    @ps_cmd
-    |> :os.cmd()
-    |> to_string()
-    |> String.trim()
-    |> String.split("\n")
-    |> Enum.map(fn x -> Regex.named_captures(~r/[^\d]*(?<pid>[\d]+)/, x)["pid"] end)
-  end
-
-  defp print_and_wait do
-    {:ok, _blob} = ChromicPDF.print_to_pdf({:html, ""})
-    :timer.sleep(@wait_ms)
-  end
+  import ChromicPDF.OSHelper
 
   describe "sessions automatically restart after a number of operations" do
     setup do
       start_supervised!({ChromicPDF, max_session_uses: 2})
-      :timer.sleep(@wait_ms)
       :ok
     end
 
     test "session restart spawns a new session process" do
-      pids0 = chrome_pids()
+      pids_before = chrome_renderer_pids()
 
-      # We have at least 1 BEAM process, 1 Chrome process, and one target process.
-      assert length(pids0) >= 3
-
-      print_and_wait()
-      pids1 = chrome_pids()
+      {:ok, _blob} = ChromicPDF.print_to_pdf({:html, ""})
 
       # After the first print operation, the pids should remain exactly the same.
-      assert pids0 == pids1
+      pids_now = chrome_renderer_pids()
+      assert pids_now == pids_before
 
-      print_and_wait()
-      pids2 = chrome_pids()
+      {:ok, _blob} = ChromicPDF.print_to_pdf({:html, ""})
 
       # After the second print operation, we expect the Session to have restarted its target
       # process, so exactly one pid should have changed.
-      assert length(pids1) == length(pids2)
-      assert assert(length(pids1 -- pids2)) == 1
-      assert assert(length(pids2 -- pids1)) == 1
+      pids_now = chrome_renderer_pids()
+      assert length(pids_before) == length(pids_now)
+      assert assert(length(pids_before -- pids_now)) == 1
+      assert assert(length(pids_now -- pids_before)) == 1
     end
   end
 end

--- a/test/integration/support/os_helper.ex
+++ b/test/integration/support/os_helper.ex
@@ -1,0 +1,23 @@
+defmodule ChromicPDF.OSHelper do
+  @moduledoc false
+
+  @ps_cmd :"ps ax | grep -v grep | grep -i Chrom | grep type=renderer"
+
+  # This gets all pids of Chrome, chromium*, chrome-browser, or whatever Chrome process on the
+  # system that have a type=renderer argument, and reads their pids from "ps" output. Chrome
+  # spawns 1 renderer per browser target (tab).
+  # Please don't mess with the "ps ax" line above, ps's options are quite cumbersome to get right
+  # in a platform-independent way.
+  def chrome_renderer_pids do
+    # Sleep for 0.5 seconds to allow Chrome initialization/termination to happen.
+    :timer.sleep(500)
+
+    @ps_cmd
+    |> :os.cmd()
+    |> to_string()
+    |> String.trim()
+    |> String.split("\n")
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.map(fn x -> Regex.named_captures(~r/[^\d]*(?<pid>[\d]+)/, x)["pid"] end)
+  end
+end


### PR DESCRIPTION
Adds an `on_demand` config option that prevents the supervisor from
starting up initially. Instead, it spawns an Agent process to store the
configuration for us, and dynamically launches the supervisor (unnamed)
as needed, and stops it after use.

This should help reducing the "zombie process" pain in development when
stopping a server / iex shell with Ctrl+C.

Addresses #56.