### PR TITLE
[#80] Wait for Page.loadEventFired after setDocumentContent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- When sending HTML to Chrome with `{:html, <content>}`, wait for the `Page.loadEventFired`
+  notification to allow external resources (images, scripts, ...) to be fetched. (#80)
+
 ## [0.6.1] - 2020-11-17
 
 ### Fixed

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -64,7 +64,6 @@ defmodule ChromicPDF.ProtocolMacros do
         )
       end
 
-      defp skip_branch([], acc, _opts), do: acc
       defp skip_branch([:end | rest], acc, opts), do: do_build_steps(rest, acc, opts)
       defp skip_branch([_skipped | rest], acc, opts), do: skip_branch(rest, acc, opts)
     end

--- a/lib/chromic_pdf/pdf/protocols/spawn_session.ex
+++ b/lib/chromic_pdf/pdf/protocols/spawn_session.ex
@@ -1,9 +1,14 @@
 defmodule ChromicPDF.SpawnSession do
   @moduledoc false
 
+  import ChromicPDF.Utils, only: [priv_asset: 1]
   import ChromicPDF.ProtocolMacros
 
   @version Mix.Project.config()[:version]
+
+  def blank_url do
+    "file://#{priv_asset("blank.html")}"
+  end
 
   steps do
     call(:create_browser_context, "Target.createBrowserContext", [], %{"disposeOnDetach" => true})
@@ -40,6 +45,11 @@ defmodule ChromicPDF.SpawnSession do
     end
 
     call(:enable_page, "Page.enable", [], %{})
+    await_response(:page_enabled, [])
+
+    call(:blank, "Page.navigate", [], %{"url" => blank_url()})
+    await_response(:blanked, ["frameId"])
+    await_notification(:fsl_after_blank, "Page.frameStoppedLoading", ["frameId"], [])
 
     output(["targetId", "sessionId"])
   end

--- a/lib/chromic_pdf/pdfa/ghostscript_worker.ex
+++ b/lib/chromic_pdf/pdfa/ghostscript_worker.ex
@@ -114,8 +114,4 @@ defmodule ChromicPDF.GhostscriptWorker do
   end
 
   defp cast_info_value(other), do: other
-
-  defp priv_asset(filename) do
-    Path.join([Application.app_dir(:chromic_pdf), "priv", filename])
-  end
 end

--- a/lib/chromic_pdf/utils.ex
+++ b/lib/chromic_pdf/utils.ex
@@ -71,4 +71,9 @@ defmodule ChromicPDF.Utils do
     |> Enum.find(fn {mod, _, _, _} -> mod == module end)
     |> elem(1)
   end
+
+  @spec priv_asset(binary()) :: binary()
+  def priv_asset(filename) do
+    Path.join([Application.app_dir(:chromic_pdf), "priv", filename])
+  end
 end

--- a/test/integration/fixtures/image_with_text.svg
+++ b/test/integration/fixtures/image_with_text.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="100">
+  <text x="0" y="80" font-size="3em">some text from an external svg</text>
+</svg>

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -3,6 +3,8 @@ defmodule ChromicPDF.PDFGenerationTest do
   import ChromicPDF.Utils, only: [system_cmd!: 2]
 
   @test_html Path.expand("../fixtures/test.html", __ENV__.file)
+  @test_image Path.expand("../fixtures/image_with_text.svg", __ENV__.file)
+
   @output Path.expand("../test.pdf", __ENV__.file)
   @test_server_port Application.compile_env!(:chromic_pdf, :test_server_port)
 
@@ -52,6 +54,15 @@ defmodule ChromicPDF.PDFGenerationTest do
     test "it prints PDF from HTML content" do
       print_to_pdf({:html, File.read!(@test_html)}, fn text ->
         assert String.contains?(text, "Hello ChromicPDF!")
+      end)
+    end
+
+    @tag :pdftotext
+    test "it waits for external resources when printing HTML content" do
+      html = ~s(<img src="file://#{@test_image}" />)
+
+      print_to_pdf({:html, html}, fn text ->
+        assert String.contains?(text, "some text from an external svg")
       end)
     end
 


### PR DESCRIPTION
This patch changes the `PrintToPDF` protocol to wait for Chrome's
`Page.loadEventFired` notification after `setDocumentContent` instead of
only for the response of the call. This gives Chrome time to fetch external
resources (`<img>`, `<script>`, etc.) from URLs before printing the page.

* Change the handling of `:await`-type protocol steps to allow multiple
  successive responses/notifications to arrive out-of-order and wait for
  all of them before continuing with the next `:call` step. This makes
  it possible to wait for both the response of the `setDocumentContent`
  call and the `loadEventFired` notification.
* Change the "blanking" of the page after printing to navigate to a local
  file (`priv/blank.html`) instead of `about:blank`, as otherwise Chrome
  refuses to fetch any `file:///` URLs contained within the HTML content.
* Navigate to the blank file before first print job in `SpawnSession`.

Fixes #80.