### PR TITLE
[83] Add global timeout option for browser interaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+- New global `timeout` option for session pool allows to configure timeout of print processes.
+
 ## [0.6.2] - 2020-12-28
 
 ### Fixed

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -27,36 +27,8 @@ defmodule ChromicPDF do
 
       ChromicPDF.print_to_pdf({:url, "file:///example.html"}, output: "output.pdf")
 
-  See `ChromicPDF.print_to_pdf/2` and `ChromicPDF.convert_to_pdfa/2`.
-
-  ## Worker pools
-
-  ChromicPDF spawns two worker pools, the session pool and the ghostscript pool. By default, it
-  will create as many sessions (browser tabs) as schedulers are online, and allow the same number
-  of concurrent Ghostscript processes to run.
-
-  ### Concurrency
-
-  To increase or limit the number of concurrent workers, you can pass pool configuration to the
-  supervisor. Please note that these are non-queueing worker pools. If you intend to max them out,
-  you will need a job queue as well.
-
-      defp chromic_pdf_opts do
-        [
-          session_pool: [size: 3]
-          ghostscript_pool: [size: 10]
-        ]
-      end
-
-  ### Automatic session restarts to avoid memory drain
-
-  By default, ChromicPDF will restart sessions within the Chrome process after 1000 operations.
-  This helps to prevent infinite growth in Chrome's memory consumption. The "max age" of a session
-  can be configured with the `:max_session_uses` option.
-
-      defp chromic_pdf_opts do
-        [max_session_uses: 1000]
-      end
+  PDF printing comes with a ton of options. Please see `ChromicPDF.print_to_pdf/2` and
+  `ChromicPDF.convert_to_pdfa/2` for details.
 
   ## Security Considerations
 
@@ -89,6 +61,47 @@ defmodule ChromicPDF do
 
       defp chromic_pdf_opts do
         [no_sandbox: true]
+      end
+
+  ## Worker pools
+
+  ChromicPDF spawns two worker pools, the session pool and the ghostscript pool. By default, it
+  will create as many sessions (browser tabs) as schedulers are online, and allow the same number
+  of concurrent Ghostscript processes to run.
+
+  ### Concurrency
+
+  To increase or limit the number of concurrent workers, you can pass pool configuration to the
+  supervisor. Please note that these are non-queueing worker pools. If you intend to max them out,
+  you will need a job queue as well.
+
+      defp chromic_pdf_opts do
+        [
+          session_pool: [size: 3]
+          ghostscript_pool: [size: 10]
+        ]
+      end
+
+  ### Operation timeouts
+
+  By default, ChromicPDF allows the print process to take 5 seconds to finish. In case you are
+  printing large PDFs and run into timeouts, these can be configured configured by passing the
+  `timeout` option to the session pool.
+
+      defp chromic_pdf_opts do
+        [
+          session_pool: [timeout: 10_000]   # in milliseconds
+        ]
+      end
+
+  ### Automatic session restarts to avoid memory drain
+
+  By default, ChromicPDF will restart sessions within the Chrome process after 1000 operations.
+  This helps to prevent infinite growth in Chrome's memory consumption. The "max age" of a session
+  can be configured with the `:max_session_uses` option.
+
+      defp chromic_pdf_opts do
+        [max_session_uses: 1000]
       end
 
   ## Chrome zombies

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -176,15 +176,16 @@ defmodule ChromicPDF.Supervisor do
               | output_option()
               | telemetry_metadata_option()
 
-      @type pool_option :: {:size, non_neg_integer()}
+      @type session_pool_option :: {:size, non_neg_integer()} | {:timeout, timeout()}
+      @type ghostscript_pool_option :: {:size, non_neg_integer()}
 
       @type global_option ::
               {:offline, boolean()}
               | {:max_session_uses, non_neg_integer()}
-              | {:session_pool, [pool_option()]}
+              | {:session_pool, [session_pool_option()]}
               | {:no_sandbox, boolean()}
               | {:discard_stderr, boolean()}
-              | {:ghostscript_pool, [pool_option()]}
+              | {:ghostscript_pool, [ghostscript_pool_option()]}
               | {:on_demand, boolean()}
 
       @doc """

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -188,4 +188,17 @@ defmodule ChromicPDF.PDFGenerationTest do
       end)
     end
   end
+
+  describe "session pool timeout" do
+    setup do
+      start_supervised!({ChromicPDF, session_pool: [timeout: 1]})
+      :ok
+    end
+
+    test "can be configured and generates a nice error messages" do
+      assert_raise RuntimeError, ~r/Timeout in Channel.run_protocol/, fn ->
+        print_to_pdf(fn _output -> :ok end)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch adds a new global `timeout` option that can be passed via the
session pool configuration and which allows to configure the GenServer
timeout (essentially how long we wait for "protocols" to complete).

Fixes #83.