### PR TITLE
Minor doc improvements to PDF/A generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ For running the full suite of integration tests, please install and have in your
 
 * [`verapdf`](https://verapdf.org/)
 * For `pdfinfo` and `pdftotext`, you need `poppler-utils` (most Linux distributions) or [Xpdf](https://www.xpdfreader.com/) (OSX)
-* For the odd ZUGFeRD test in [`pdfa_generation_test.exs`](test/integration/pdfa_generation_test.exs), you need to download [ZUV](https://github.com/ZUGFeRD/ZUV) and set the `$ZUV_JAR` environment variable.
+* For the odd ZUGFeRD test in [`zugferd_test.exs`](test/integration/zugferd_test.exs), you need to download [ZUV](https://github.com/ZUGFeRD/ZUV) and set the `$ZUV_JAR` environment variable.

--- a/lib/chromic_pdf/api.ex
+++ b/lib/chromic_pdf/api.ex
@@ -7,9 +7,7 @@ defmodule ChromicPDF.API do
   @spec print_to_pdf(
           ChromicPDF.Supervisor.services(),
           ChromicPDF.source() | ChromicPDF.source_and_options(),
-          [
-            ChromicPDF.pdf_option()
-          ]
+          [ChromicPDF.pdf_option()]
         ) :: ChromicPDF.return()
   def print_to_pdf(services, %{source: source, opts: opts}, overrides)
       when tuple_size(source) == 2 and is_list(opts) and is_list(overrides) do

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -158,6 +158,18 @@ defmodule ChromicPDF.Supervisor do
 
       @type telemetry_metadata_option :: {:telemetry_metadata, map()}
 
+      @type info_option ::
+              {:info,
+               %{
+                 optional(:title) => binary(),
+                 optional(:author) => binary(),
+                 optional(:subject) => binary(),
+                 optional(:keywords) => binary(),
+                 optional(:creator) => binary(),
+                 optional(:creation_date) => binary(),
+                 optional(:mod_date) => binary()
+               }}
+
       @type wait_for_option ::
               {:wait_for,
                %{
@@ -168,6 +180,7 @@ defmodule ChromicPDF.Supervisor do
       @type pdf_option ::
               {:print_to_pdf, map()}
               | {:set_cookie, map()}
+              | info_option()
               | output_option()
               | telemetry_metadata_option()
               | wait_for_option()
@@ -175,7 +188,7 @@ defmodule ChromicPDF.Supervisor do
       @type pdfa_option ::
               {:pdfa_version, binary()}
               | {:pdfa_def_ext, binary()}
-              | {:info, map()}
+              | info_option()
               | output_option()
               | telemetry_metadata_option()
 
@@ -537,8 +550,7 @@ defmodule ChromicPDF.Supervisor do
       ## Adding more PostScript to the conversion
 
       The `pdfa_def_ext` option can be used to feed more PostScript code into the final conversion
-      step. This can be useful to add additional features to the generated PDF-A file, for
-      instance a ZUGFeRD invoice.
+      step.
 
           ChromicPDF.convert_to_pdfa(
             "some_pdf_file.pdf",

--- a/test/integration/zugferd_test.exs
+++ b/test/integration/zugferd_test.exs
@@ -1,0 +1,47 @@
+defmodule ChromicPDF.ZUGFeRDTest do
+  use ExUnit.Case, async: false
+  import ChromicPDF.Utils, only: [system_cmd!: 2]
+  require EEx
+
+  @test_html Path.expand("../fixtures/test.html", __ENV__.file)
+  @zugferd_invoice_xml Path.expand("../fixtures/zugferd-invoice.xml", __ENV__.file)
+  @embed_xml_ps_eex Path.expand("../fixtures/embed_xml.ps.eex", __ENV__.file)
+
+  @external_resource @embed_xml_ps_eex
+  EEx.function_from_file(:defp, :render_embed_xml_ps, @embed_xml_ps_eex, [:assigns])
+
+  describe "generating ZUGFeRD-compliant invoices" do
+    defp print_to_pdfa(opts, cb) do
+      opts = Keyword.put(opts, :output, cb)
+      assert {:ok, _} = ChromicPDF.print_to_pdfa({:url, "file://#{@test_html}"}, opts)
+    end
+
+    setup do
+      {:ok, _pid} = start_supervised(ChromicPDF)
+      :ok
+    end
+
+    @tag :zuv
+    test "the PDF/A converter can run additional PostScript" do
+      embed_xml_ps =
+        render_embed_xml_ps(
+          zugferd_xml: @zugferd_invoice_xml,
+          zugferd_xml_file_date: ChromicPDF.Utils.to_postscript_date(DateTime.utc_now())
+        )
+
+      pdfa_opts = [
+        pdfa_def_ext: embed_xml_ps
+      ]
+
+      print_to_pdfa(pdfa_opts, fn file ->
+        output =
+          system_cmd!(
+            "java",
+            ["-jar", System.fetch_env!("ZUV_JAR"), "--action", "validate", "-f", file]
+          )
+
+        assert String.contains?(output, ~S(validationReports compliant="1"))
+      end)
+    end
+  end
+end


### PR DESCRIPTION
* Move ZUGFeRD test to its own file.
* Remove mention of ZUGFeRD from `convert_to_pdfa/2` doc.
* Typespec `:info` option with allowed keys.