### PR TITLE
Shared protocol fragments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Added `evaluate` option to run client-side scripts before printing.
+- Added a few options (`evaluate`, `set_cookie`, `wait_for`) to `capture_screenshot/2`.
 
 ### Changed
 

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -38,7 +38,6 @@ defmodule ChromicPDF.ProtocolMacros do
         @steps
         |> Enum.reverse()
         |> do_build_steps([], opts)
-        |> Enum.reverse()
       end
 
       defp do_build_steps([], acc, _opts), do: acc
@@ -63,10 +62,14 @@ defmodule ChromicPDF.ProtocolMacros do
         end
       end
 
+      defp do_build_steps([{:include_protocol, protocol_mod} | rest], acc, opts) do
+        do_build_steps(rest, acc ++ protocol_mod.new(opts).steps, opts)
+      end
+
       defp do_build_steps([{type, name, arity} | rest], acc, opts) do
         do_build_steps(
           rest,
-          [{type, Function.capture(__MODULE__, name, arity)} | acc],
+          acc ++ [{type, Function.capture(__MODULE__, name, arity)}],
           opts
         )
       end
@@ -89,6 +92,12 @@ defmodule ChromicPDF.ProtocolMacros do
       @steps {:if_option, unquote(test_key)}
       unquote(block)
       @steps :end
+    end
+  end
+
+  defmacro include_protocol(protocol_mod) do
+    quote do
+      @steps {:include_protocol, unquote(protocol_mod)}
     end
   end
 

--- a/lib/chromic_pdf/pdf/protocols/capture_screenshot.ex
+++ b/lib/chromic_pdf/pdf/protocols/capture_screenshot.ex
@@ -4,21 +4,12 @@ defmodule ChromicPDF.CaptureScreenshot do
   import ChromicPDF.ProtocolMacros
 
   steps do
-    if_option {:source_type, :html} do
-      call(:get_frame_tree, "Page.getFrameTree", [], %{})
-      await_response(:frame_tree, [{["frameTree", "frame", "id"], "frameId"}])
-      call(:set_content, "Page.setDocumentContent", [:html, "frameId"], %{})
-      await_response(:content_set, [])
-    end
-
-    if_option {:source_type, :url} do
-      call(:navigate, "Page.navigate", [:url], %{})
-      await_response(:navigated, ["frameId"])
-      await_notification(:frame_stopped_loading, "Page.frameStoppedLoading", ["frameId"], [])
-    end
+    include_protocol(ChromicPDF.Navigate)
 
     call(:capture, "Page.captureScreenshot", &Map.get(&1, :capture_screenshot, %{}), %{})
     await_response(:captured, ["data"])
+
+    include_protocol(ChromicPDF.ResetTarget)
 
     output("data")
   end

--- a/lib/chromic_pdf/pdf/protocols/navigate.ex
+++ b/lib/chromic_pdf/pdf/protocols/navigate.ex
@@ -1,0 +1,52 @@
+defmodule ChromicPDF.Navigate do
+  @moduledoc false
+
+  import ChromicPDF.ProtocolMacros
+
+  steps do
+    if_option :set_cookie do
+      call(:set_cookie, "Network.setCookie", &Map.fetch!(&1, :set_cookie), %{})
+      await_response(:cookie_set, [])
+    end
+
+    if_option {:source_type, :html} do
+      call(:get_frame_tree, "Page.getFrameTree", [], %{})
+      await_response(:frame_tree, [{["frameTree", "frame", "id"], "frameId"}])
+      call(:set_content, "Page.setDocumentContent", [:html, "frameId"], %{})
+      await_response(:content_set, [])
+      await_notification(:page_load_event, "Page.loadEventFired", [], [])
+    end
+
+    if_option {:source_type, :url} do
+      call(:navigate, "Page.navigate", [:url], %{})
+
+      await_response(:navigated, ["frameId"]) do
+        case get_in(msg, ["result", "errorText"]) do
+          nil ->
+            :ok
+
+          error ->
+            {:error, error}
+        end
+      end
+
+      await_notification(:frame_stopped_loading, "Page.frameStoppedLoading", ["frameId"], [])
+    end
+
+    if_option :evaluate do
+      call(:evaluate, "Runtime.evaluate", [{"expression", [:evaluate, :expression]}], %{
+        awaitPromise: true
+      })
+
+      await_response(:evaluated, []) do
+        case get_in(msg, ["result", "exceptionDetails"]) do
+          nil ->
+            :ok
+
+          %{"exception" => %{"description" => error}} ->
+            {:error, "[evaluate] #{error}"}
+        end
+      end
+    end
+  end
+end

--- a/lib/chromic_pdf/pdf/protocols/print_to_pdf.ex
+++ b/lib/chromic_pdf/pdf/protocols/print_to_pdf.ex
@@ -1,70 +1,15 @@
 defmodule ChromicPDF.PrintToPDF do
   @moduledoc false
 
-  import ChromicPDF.SpawnSession, only: [blank_url: 0]
   import ChromicPDF.ProtocolMacros
-  alias ChromicPDF.Protocol
 
   steps do
-    if_option :set_cookie do
-      call(:set_cookie, "Network.setCookie", &Map.fetch!(&1, :set_cookie), %{})
-      await_response(:cookie_set, [])
-    end
-
-    if_option {:source_type, :html} do
-      call(:get_frame_tree, "Page.getFrameTree", [], %{})
-      await_response(:frame_tree, [{["frameTree", "frame", "id"], "frameId"}])
-      call(:set_content, "Page.setDocumentContent", [:html, "frameId"], %{})
-      await_response(:content_set, [])
-      await_notification(:page_load_event, "Page.loadEventFired", [], [])
-    end
-
-    if_option {:source_type, :url} do
-      call(:navigate, "Page.navigate", [:url], %{})
-
-      await_response(:navigated, ["frameId"]) do
-        case get_in(msg, ["result", "errorText"]) do
-          nil ->
-            :ok
-
-          error ->
-            {:error, error}
-        end
-      end
-
-      await_notification(:frame_stopped_loading, "Page.frameStoppedLoading", ["frameId"], [])
-    end
-
-    if_option :evaluate do
-      call(:evaluate, "Runtime.evaluate", [{"expression", [:evaluate, :expression]}], %{
-        awaitPromise: true
-      })
-
-      await_response(:evaluated, []) do
-        case get_in(msg, ["result", "exceptionDetails"]) do
-          nil ->
-            :ok
-
-          %{"exception" => %{"description" => error}} ->
-            {:error, "[evaluate] #{error}"}
-        end
-      end
-    end
+    include_protocol(ChromicPDF.Navigate)
 
     call(:print_to_pdf, "Page.printToPDF", &Map.get(&1, :print_to_pdf, %{}), %{})
     await_response(:printed, ["data"])
 
-    call(:reset_history, "Page.resetNavigationHistory", [], %{})
-    await_response(:history_reset, [])
-
-    if_option :set_cookie do
-      call(:clear_cookies, "Network.clearBrowserCookies", [], %{})
-      await_response(:cleared, [])
-    end
-
-    call(:blank, "Page.navigate", [], %{"url" => blank_url()})
-    await_response(:blanked, ["frameId"])
-    await_notification(:fsl_after_blank, "Page.frameStoppedLoading", ["frameId"], [])
+    include_protocol(ChromicPDF.ResetTarget)
 
     output("data")
   end

--- a/lib/chromic_pdf/pdf/protocols/reset_target.ex
+++ b/lib/chromic_pdf/pdf/protocols/reset_target.ex
@@ -1,0 +1,24 @@
+defmodule ChromicPDF.ResetTarget do
+  @moduledoc false
+
+  import ChromicPDF.ProtocolMacros
+  import ChromicPDF.Utils, only: [priv_asset: 1]
+
+  defp blank_url do
+    "file://#{priv_asset("blank.html")}"
+  end
+
+  steps do
+    call(:reset_history, "Page.resetNavigationHistory", [], %{})
+    await_response(:history_reset, [])
+
+    if_option :set_cookie do
+      call(:clear_cookies, "Network.clearBrowserCookies", [], %{})
+      await_response(:cleared, [])
+    end
+
+    call(:blank, "Page.navigate", [], %{"url" => blank_url()})
+    await_response(:blanked, ["frameId"])
+    await_notification(:fsl_after_blank, "Page.frameStoppedLoading", ["frameId"], [])
+  end
+end

--- a/lib/chromic_pdf/pdf/protocols/spawn_session.ex
+++ b/lib/chromic_pdf/pdf/protocols/spawn_session.ex
@@ -1,14 +1,9 @@
 defmodule ChromicPDF.SpawnSession do
   @moduledoc false
 
-  import ChromicPDF.Utils, only: [priv_asset: 1]
   import ChromicPDF.ProtocolMacros
 
   @version Mix.Project.config()[:version]
-
-  def blank_url do
-    "file://#{priv_asset("blank.html")}"
-  end
 
   steps do
     call(:create_browser_context, "Target.createBrowserContext", [], %{"disposeOnDetach" => true})
@@ -55,9 +50,7 @@ defmodule ChromicPDF.SpawnSession do
     call(:enable_page, "Page.enable", [], %{})
     await_response(:page_enabled, [])
 
-    call(:blank, "Page.navigate", [], %{"url" => blank_url()})
-    await_response(:blanked, ["frameId"])
-    await_notification(:fsl_after_blank, "Page.frameStoppedLoading", ["frameId"], [])
+    include_protocol(ChromicPDF.ResetTarget)
 
     output(["targetId", "sessionId"])
   end

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -179,14 +179,16 @@ defmodule ChromicPDF.Supervisor do
                  required(:attribute) => binary()
                }}
 
-      @type pdf_option ::
-              {:print_to_pdf, map()}
-              | {:set_cookie, map()}
-              | info_option()
-              | output_option()
-              | telemetry_metadata_option()
+      @type navigate_option ::
+              {:set_cookie, map()}
               | evaluate_option()
               | wait_for_option()
+
+      @type pdf_option ::
+              {:print_to_pdf, map()}
+              | navigate_option()
+              | output_option()
+              | telemetry_metadata_option()
 
       @type pdfa_option ::
               {:pdfa_version, binary()}
@@ -197,6 +199,7 @@ defmodule ChromicPDF.Supervisor do
 
       @type capture_screenshot_option ::
               {:capture_screenshot, map()}
+              | navigate_option()
               | output_option()
               | telemetry_metadata_option()
 
@@ -505,7 +508,8 @@ defmodule ChromicPDF.Supervisor do
 
       ## Options
 
-      Options can be passed by passing a map to the `:capture_screenshot` key.
+      Options to the [`Page.captureScrenshot`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-captureScreenshot)
+      call can be passed by passing a map to the `:capture_screenshot` option.
 
           ChromicPDF.capture_screenshot(
             {:url, "file:///example.html"},
@@ -514,9 +518,7 @@ defmodule ChromicPDF.Supervisor do
             }
           )
 
-      Please see docs for details:
-
-      https://chromedevtools.github.io/devtools-protocol/tot/Page#method-captureScreenshot
+      For navigational options (source, cookies, evaluating scripts) see `print_to_pdf/2`.
       """
       @spec capture_screenshot(url :: source(), opts :: [capture_screenshot_option()]) :: return()
       def capture_screenshot(input, opts \\ []) do


### PR DESCRIPTION
* Add new `include_protocol` macro to the `ProtocolMacros` which builds
  a shared protocol and merges its steps into the current protocol.
* Extract `Navigate` and `Blank` protocols from `PrintToPDF` and use
  them in `CaptureScreenshot` (gains all navigational options from
  `print_to_pdf/2`!) and `SpawnSession`.