### PR TITLE
[120] Explicit connection lost error and helpful sandbox docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Changed
+
+- Improved error message when Chrome dies at startup.
+- Improved docs on the `no_sandbox` option.
+
 ## [1.0.0] - 2021-03-23
 
 ### Added

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -54,10 +54,25 @@ defmodule ChromicPDF do
         [offline: true]
       end
 
-  ### Chrome Sandbox
+  ### Chrome Sandbox in Docker containers
 
-  By default, ChromicPDF will run Chrome targets in a sandboxed OS process. If you absolutely
-  must run Chrome as root, you can turn of its sandbox by passing the `no_sandbox: true` option.
+  By default, ChromicPDF will allow Chrome to make use of its own ["sandbox" process jail](https://chromium.googlesource.com/chromium/src/+/master/docs/design/sandbox.md).
+  The sandbox tries to limit system resource access of the renderer processes to the minimum
+  resources they require to perform their task.
+
+  However, in Docker containers running Linux images (e.g. images based on Alpine), and which
+  are configured to run their main job as a non-root user, this causes Chrome to crash on startup
+  as it requires root privileges to enter the sandbox.
+
+  The error output (`discard_stderr: false` option) looks as follows:
+
+      Failed to move to new namespace: PID namespaces supported, Network namespace supported,
+      but failed: errno = Operation not permitted
+
+  The best way to resolve this issue is to configure your Docker container to use seccomp rules
+  that grant Chrome access to the relevant system calls. See the excellent [Zenika/alpine-chrome](https://github.com/Zenika/alpine-chrome#-the-best-with-seccomp) repository for details on how to make this work.
+
+  Alternatively, you may choose to disable Chrome's sandbox with the `no_sandbox` option.
 
       defp chromic_pdf_opts do
         [no_sandbox: true]

--- a/lib/chromic_pdf/pdf/connection/connection_lost.ex
+++ b/lib/chromic_pdf/pdf/connection/connection_lost.ex
@@ -1,0 +1,7 @@
+defmodule ChromicPDF.Connection.ConnectionLostError do
+  @moduledoc """
+  Exception raised when Chrome process has stopped unexpectedly.
+  """
+
+  defexception [:message]
+end

--- a/test/integration/connection_lost_test.exs
+++ b/test/integration/connection_lost_test.exs
@@ -1,0 +1,27 @@
+defmodule ChromicPDF.ConnectionLostTest do
+  use ExUnit.Case, async: false
+  alias ChromicPDF.Connection
+  alias ChromicPDF.Connection.ConnectionLostError
+
+  describe "when the Chrome process fails at startup or is killed externally" do
+    @tag :capture_log
+    test "an exception with a nice error message is raised" do
+      {:ok, pid} = Connection.start_link(self(), [])
+
+      port_info = Connection.port_info(pid)
+
+      Process.unlink(pid)
+      Process.monitor(pid)
+
+      System.cmd("kill", [to_string(port_info[:os_pid])])
+
+      receive do
+        {:DOWN, _ref, :process, ^pid, {%ConnectionLostError{message: msg}, _trace}} ->
+          assert String.contains?(
+                   msg,
+                   "Chrome has stopped or was terminated by an external program."
+                 )
+      end
+    end
+  end
+end

--- a/test/unit/chromic_pdf/pdf/connection_test.exs
+++ b/test/unit/chromic_pdf/pdf/connection_test.exs
@@ -9,6 +9,7 @@ defmodule ChromicPDF.ConnectionTest do
 
   defp new_state do
     %{
+      port: @port,
       parent_pid: self(),
       tokenizer: [],
       dispatcher: %ChromicPDF.Connection.Dispatcher{
@@ -35,10 +36,10 @@ defmodule ChromicPDF.ConnectionTest do
 
     test "it suicides when Chrome is terminated externally", %{state: state} do
       assert handle_info({:EXIT, @port, :normal}, state) ==
-               {:stop, :connection_terminated, state}
+               {:stop, :connection_lost, state}
 
       assert handle_info({:EXIT, @port, :other_reason}, state) ==
-               {:stop, :connection_terminated, state}
+               {:stop, :connection_lost, state}
     end
   end
 


### PR DESCRIPTION
* When Chrome dies at startup, display a helpful error message.
* Improve sandbox docs, mention Docker & seccomp.

Addresses #120.