### PR TITLE
Fix broken link in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ convenient API. See the documentation for details.
 
 ### Examples
 
-* For a more complete example of how to integrate ChromicPDF in a Phoenix application, see [examples/phoenix](examples/phoenix).
+* For a more complete example of how to integrate ChromicPDF in a Phoenix application, see [examples/phoenix](https://github.com/bitcrowd/chromic_pdf/tree/main/examples/phoenix).
 
 ## Development
 


### PR DESCRIPTION
As the README is part of the hexdocs documentation (see mix.exs), links
need to be absolute.

```
$ mix docs
Generating docs...
warning: documentation references file "examples/phoenix" but it does not exist
  README.md
```