### PR TITLE
Add Chromium path on macOS

### DIFF
--- a/lib/chromic_pdf/pdf/chrome_impl.ex
+++ b/lib/chromic_pdf/pdf/chrome_impl.ex
@@ -44,7 +44,8 @@ defmodule ChromicPDF.ChromeImpl do
     "chromium-browser",
     "chromium",
     "google-chrome",
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium"
   ]
 
   defp chrome_executable(nil) do


### PR DESCRIPTION
This adds the Chromium path for macOS users.

Edit: reference is https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/eloston-chromium.rb that does not add the binary to $PATH.