### PR TITLE
[#136] Support Stream

### DIFF
--- a/lib/chromic_pdf/api/pdf_options.ex
+++ b/lib/chromic_pdf/api/pdf_options.ex
@@ -5,12 +5,23 @@ defmodule ChromicPDF.PDFOptions do
   require EEx
   alias ChromicPDF.ChromeError
 
-  def prepare_export_options(source, opts) do
+  def prepare_export_options(protocol, source, opts) do
+    validate_options!(protocol, source, opts)
+
     opts
     |> put_source(source)
     |> replace_wait_for_with_evaluate()
     |> stringify_map_keys()
     |> iolists_to_binary()
+  end
+
+  defp validate_options!(:print_to_pdf_as_stream, _source, opts) do
+    if Keyword.get(opts, :output) do
+      raise(":output option is not supported for print_to_pdf_as_stream/2")
+    end
+  end
+
+  defp validate_options!(_protocol, _source, _opts) do
   end
 
   defp put_source(opts, {:file, source}), do: put_source(opts, {:url, source})

--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -18,11 +18,33 @@ defmodule ChromicPDF.Browser do
   @spec session_pool(pid()) :: pid()
   def session_pool(supervisor), do: find_supervisor_child(supervisor, SessionPool)
 
-  @spec run_protocol(pid(), module(), keyword()) :: {:ok, any()} | {:error, term()}
-  def run_protocol(supervisor, protocol, params) do
+  @spec spawn_session(pid()) :: Channel.session()
+  def spawn_session(supervisor) do
+    supervisor
+    |> channel()
+    |> Channel.spawn_session()
+  end
+
+  @spec close_session(pid(), Channel.session()) :: :ok
+  def close_session(supervisor, session) do
+    supervisor
+    |> channel()
+    |> Channel.close_session(session)
+  end
+
+  @spec run_protocol(pid(), Channel.session(), module(), keyword()) ::
+          {:ok, any()} | {:error, term()}
+  def run_protocol(supervisor, session, protocol, params) do
+    supervisor
+    |> channel()
+    |> Channel.run_protocol(session, protocol, params)
+  end
+
+  @spec checkout_session(pid(), (Channel.session() -> any())) :: any()
+  def checkout_session(supervisor, callback) do
     supervisor
     |> session_pool()
-    |> SessionPool.run_protocol(protocol, params)
+    |> SessionPool.checkout!(callback)
   end
 
   # ------------ Callbacks -----------

--- a/lib/chromic_pdf/pdf/browser/channel.ex
+++ b/lib/chromic_pdf/pdf/browser/channel.ex
@@ -2,12 +2,24 @@ defmodule ChromicPDF.Browser.Channel do
   @moduledoc false
 
   use GenServer
-  alias ChromicPDF.{Connection, Protocol}
+  alias ChromicPDF.{CloseTarget, Connection, Protocol, SpawnSession}
 
-  @enforce_keys [:dispatch, :protocols]
-  defstruct [:dispatch, :protocols]
+  @enforce_keys [:dispatch, :spawn_protocol, :protocols, :timeout]
+  defstruct [:dispatch, :spawn_protocol, :protocols, :timeout]
 
-  @type t :: %__MODULE__{dispatch: Protocol.dispatch(), protocols: [Protocol.t()]}
+  @type t :: %__MODULE__{
+          dispatch: Protocol.dispatch(),
+          spawn_protocol: Protocol.t(),
+          protocols: [Protocol.t()]
+        }
+
+  @type session :: %{
+          session_id: binary(),
+          target_id: binary()
+        }
+
+  @default_timeout 5000
+  @session_operation_timeout 1000
 
   # ------------- API ----------------
 
@@ -16,8 +28,36 @@ defmodule ChromicPDF.Browser.Channel do
     GenServer.start_link(__MODULE__, args)
   end
 
-  @spec run_protocol(pid(), Protocol.t(), timeout()) :: {:ok, any()} | {:error, term()}
-  def run_protocol(pid, %Protocol{} = protocol, timeout) do
+  @spec spawn_session(pid()) :: session()
+  def spawn_session(pid) do
+    {:ok, %{"sessionId" => sid, "targetId" => tid}} =
+      GenServer.call(pid, :spawn_session, @session_operation_timeout)
+
+    %{session_id: sid, target_id: tid}
+  end
+
+  @spec close_session(pid(), session()) :: :ok
+  def close_session(pid, %{target_id: tid}) do
+    protocol = CloseTarget.new(targetId: tid)
+
+    {:ok, _} = GenServer.call(pid, {:run_protocol, protocol}, @session_operation_timeout)
+
+    :ok
+  end
+
+  @spec run_protocol(pid(), session(), protocol_mod :: module(), params :: keyword()) ::
+          {:ok, any()} | {:error, term()}
+  def run_protocol(pid, session, protocol_mod, params) do
+    timeout = GenServer.call(pid, :timeout)
+
+    run_protocol(pid, session, protocol_mod, params, timeout)
+  end
+
+  @spec run_protocol(pid(), session(), protocol_mod :: module(), params :: keyword(), timeout()) ::
+          {:ok, any()} | {:error, term()}
+  def run_protocol(pid, %{session_id: sid}, protocol_mod, params, timeout) do
+    protocol = protocol_mod.new(sid, params)
+
     GenServer.call(pid, {:run_protocol, protocol}, timeout)
   catch
     :exit, {:timeout, {GenServer, :call, [_pid, {:run_protocol, _protocol}, _timeout]}} ->
@@ -46,19 +86,34 @@ defmodule ChromicPDF.Browser.Channel do
       Connection.dispatch_call(conn, call)
     end
 
-    {:ok, %__MODULE__{dispatch: dispatch, protocols: []}}
+    {:ok,
+     %__MODULE__{
+       dispatch: dispatch,
+       spawn_protocol: spawn_protocol(args),
+       protocols: [],
+       timeout: timeout(args)
+     }}
+  end
+
+  defp timeout(args) do
+    # TODO: deprecate this option in favour of a better suited one?
+    get_in(args, [:session_pool, :timeout]) || @default_timeout
   end
 
   @impl GenServer
-  # Starts protocol processing, asynchronously sends result message when done.
-  def handle_call(
-        {:run_protocol, protocol},
-        from,
-        %__MODULE__{dispatch: dispatch, protocols: protocols} = state
-      ) do
-    protocol = Protocol.init(protocol, &GenServer.reply(from, &1), dispatch)
+  # Starts the spawn protocol.
+  def handle_call(:spawn_session, from, %__MODULE__{spawn_protocol: spawn_protocol} = state) do
+    {:noreply, init_protocol(spawn_protocol, from, state)}
+  end
 
-    {:noreply, update_protocols(state, [protocol | protocols])}
+  # Starts protocol processing, asynchronously sends result message when done.
+  def handle_call({:run_protocol, protocol}, from, %__MODULE__{} = state) do
+    {:noreply, init_protocol(protocol, from, state)}
+  end
+
+  # Fetches the default timeout from the state.
+  def handle_call(:timeout, _from, %__MODULE__{timeout: timeout} = state) do
+    {:reply, timeout, state}
   end
 
   @impl GenServer
@@ -67,6 +122,19 @@ defmodule ChromicPDF.Browser.Channel do
     protocols = Enum.map(protocols, &Protocol.run(&1, msg, dispatch))
 
     {:noreply, update_protocols(state, protocols)}
+  end
+
+  defp spawn_protocol(args) do
+    args
+    |> Keyword.put_new(:offline, false)
+    |> Keyword.put_new(:ignore_certificate_errors, false)
+    |> SpawnSession.new()
+  end
+
+  defp init_protocol(protocol, from, %{dispatch: dispatch, protocols: protocols} = state) do
+    protocol = Protocol.init(protocol, &GenServer.reply(from, &1), dispatch)
+
+    update_protocols(state, [protocol | protocols])
   end
 
   defp update_protocols(state, protocols) do

--- a/lib/chromic_pdf/pdf/browser/session_pool.ex
+++ b/lib/chromic_pdf/pdf/browser/session_pool.ex
@@ -5,22 +5,16 @@ defmodule ChromicPDF.Browser.SessionPool do
 
   import ChromicPDF.Utils, only: [default_pool_size: 0]
   alias ChromicPDF.Browser
-  alias ChromicPDF.Browser.Channel
-  alias ChromicPDF.{CloseTarget, Protocol, SpawnSession}
 
-  @default_timeout 5000
   @default_max_session_uses 1000
 
   @type pool_state :: %{
           browser: pid(),
-          spawn_protocol: Protocol.t(),
-          max_session_uses: non_neg_integer(),
-          timeout: timeout()
+          max_session_uses: non_neg_integer()
         }
 
   @type worker_state :: %{
-          session_id: binary(),
-          target_id: binary(),
+          session: Browser.Channel.session(),
           uses: non_neg_integer()
         }
 
@@ -46,29 +40,12 @@ defmodule ChromicPDF.Browser.SessionPool do
     get_in(args, [:session_pool, :size]) || default_pool_size()
   end
 
-  @spec run_protocol(pid(), module(), keyword()) :: {:ok, any()} | {:error, term()}
-  def run_protocol(pid, protocol_mod, params) do
-    NimblePool.checkout!(
-      pid,
-      command(protocol_mod),
-      fn _, {channel, %{session_id: session_id}, timeout} ->
-        protocol = protocol_mod.new(session_id, params)
-        result = Channel.run_protocol(channel, protocol, timeout)
-
-        {result, :ok}
-      end
-    )
+  @spec checkout!(pid(), function()) :: any()
+  def checkout!(pid, callback) do
+    NimblePool.checkout!(pid, :checkout, fn _, session -> {callback.(session), :checkin} end)
   end
 
-  defp command(protocol_mod) do
-    if protocol_mod.increment_session_use_count?() do
-      :checkout_and_count
-    else
-      :checkout
-    end
-  end
-
-  # ------------ Callbacks -----------
+  # ------------- Callbacks ----------------
 
   @impl NimblePool
   @spec init_pool({pid(), keyword()}) :: {:ok, pool_state()}
@@ -76,72 +53,48 @@ defmodule ChromicPDF.Browser.SessionPool do
     {:ok,
      %{
        browser: browser,
-       spawn_protocol: spawn_protocol(args),
-       max_session_uses: max_session_uses(args),
-       timeout: timeout(args)
+       max_session_uses: max_session_uses(args)
      }}
-  end
-
-  defp timeout(args) do
-    get_in(args, [:session_pool, :timeout]) || @default_timeout
   end
 
   defp max_session_uses(args) do
     Keyword.get(args, :max_session_uses, @default_max_session_uses)
   end
 
-  defp spawn_protocol(args) do
-    args
-    |> Keyword.put_new(:offline, false)
-    |> Keyword.put_new(:ignore_certificate_errors, false)
-    |> SpawnSession.new()
-  end
-
   @impl NimblePool
   @spec init_worker(pool_state()) :: {:async, (() -> worker_state()), pool_state()}
-  def init_worker(%{browser: browser, spawn_protocol: spawn_protocol} = pool_state) do
-    {:async, fn -> do_init_worker(browser, spawn_protocol) end, pool_state}
+  def init_worker(%{browser: browser} = pool_state) do
+    {:async, fn -> do_init_worker(browser) end, pool_state}
   end
 
-  defp do_init_worker(browser, spawn_protocol) do
-    {:ok, %{"sessionId" => sid, "targetId" => tid}} =
-      browser
-      |> Browser.channel()
-      |> Channel.run_protocol(spawn_protocol, @default_timeout)
-
-    %{session_id: sid, target_id: tid, uses: 0}
-  end
-
-  @impl NimblePool
-  def handle_checkout(:checkout_and_count, from, session, pool_state) do
-    handle_checkout(:checkout, from, increment_uses_count(session), pool_state)
-  end
-
-  def handle_checkout(:checkout, _from, session, pool_state) do
-    client_state = {Browser.channel(pool_state.browser), session, pool_state.timeout}
-    {:ok, client_state, session, pool_state}
-  end
-
-  defp increment_uses_count(%{uses: uses} = session) do
-    %{session | uses: uses + 1}
+  defp do_init_worker(browser) do
+    %{
+      session: Browser.spawn_session(browser),
+      uses: 0
+    }
   end
 
   @impl NimblePool
-  def handle_checkin(:ok, _from, session, pool_state) do
-    if session.uses >= pool_state.max_session_uses do
+  def handle_checkout(:checkout, _from, worker_state, pool_state) do
+    # increment use count
+    worker_state = %{worker_state | uses: worker_state.uses + 1}
+
+    {:ok, worker_state.session, worker_state, pool_state}
+  end
+
+  @impl NimblePool
+  def handle_checkin(:checkin, _from, worker_state, pool_state) do
+    if worker_state.uses >= pool_state.max_session_uses do
       {:remove, :max_session_uses_reached, pool_state}
     else
-      {:ok, session, pool_state}
+      {:ok, worker_state, pool_state}
     end
   end
 
   @impl NimblePool
   def terminate_worker(:max_session_uses_reached, session, pool_state) do
     Task.async(fn ->
-      {:ok, true} =
-        pool_state.browser
-        |> Browser.channel()
-        |> Channel.run_protocol(CloseTarget.new(targetId: session.target_id), @default_timeout)
+      {:ok, true} = Browser.close_session(pool_state.browser, session)
     end)
 
     {:ok, pool_state}

--- a/lib/chromic_pdf/pdf/protocol.ex
+++ b/lib/chromic_pdf/pdf/protocol.ex
@@ -41,7 +41,6 @@ defmodule ChromicPDF.Protocol do
   @type result :: {:ok, any()} | {:error, term()}
   @type result_fun :: (result() -> any())
 
-  @callback increment_session_use_count?() :: boolean()
   @callback new(keyword()) :: __MODULE__.t()
   @callback new(JsonRPC.session_id(), keyword()) :: __MODULE__.t()
 

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -2,9 +2,7 @@ defmodule ChromicPDF.ProtocolMacros do
   @moduledoc false
 
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  defmacro steps(opts \\ [], do: block) do
-    increment_session_use_count = Keyword.get(opts, :increment_session_use_count, true)
-
+  defmacro steps(do: block) do
     quote do
       alias ChromicPDF.Connection.JsonRPC
       alias ChromicPDF.Protocol
@@ -14,9 +12,6 @@ defmodule ChromicPDF.ProtocolMacros do
       Module.register_attribute(__MODULE__, :steps, accumulate: true)
 
       unquote(block)
-
-      @impl Protocol
-      def increment_session_use_count?, do: unquote(increment_session_use_count)
 
       @impl Protocol
       def new(opts \\ []) do

--- a/lib/chromic_pdf/pdf/protocols/close_stream.ex
+++ b/lib/chromic_pdf/pdf/protocols/close_stream.ex
@@ -1,0 +1,11 @@
+defmodule ChromicPDF.CloseStream do
+  @moduledoc false
+
+  import ChromicPDF.ProtocolMacros
+
+  steps do
+    call(:close_stream, "IO.close", ["handle"], %{})
+    await_response(:stream_closed, [])
+    output([])
+  end
+end

--- a/lib/chromic_pdf/pdf/protocols/print_to_pdf_as_stream.ex
+++ b/lib/chromic_pdf/pdf/protocols/print_to_pdf_as_stream.ex
@@ -1,4 +1,4 @@
-defmodule ChromicPDF.PrintToPDF do
+defmodule ChromicPDF.PrintToPDFAsStream do
   @moduledoc false
 
   import ChromicPDF.ProtocolMacros
@@ -7,16 +7,16 @@ defmodule ChromicPDF.PrintToPDF do
     include_protocol(ChromicPDF.Navigate)
 
     call(:print_to_pdf, "Page.printToPDF", &print_to_pdf_opts/1, %{})
-    await_response(:printed, ["data"])
+    await_response(:printed, ["stream"])
 
     include_protocol(ChromicPDF.ResetTarget)
 
-    output("data")
+    output("stream")
   end
 
   defp print_to_pdf_opts(params) do
     params
     |> Map.get(:print_to_pdf, %{})
-    |> Map.put(:transferMode, "ReturnAsBase64")
+    |> Map.put(:transferMode, "ReturnAsStream")
   end
 end

--- a/lib/chromic_pdf/pdf/protocols/read_from_stream.ex
+++ b/lib/chromic_pdf/pdf/protocols/read_from_stream.ex
@@ -1,0 +1,21 @@
+defmodule ChromicPDF.ReadFromStream do
+  @moduledoc false
+
+  import ChromicPDF.ProtocolMacros
+
+  steps do
+    call(:read_from_stream, "IO.read", &read_opts/1, %{})
+    await_response(:read_from_stream_done, ["data", "eof"])
+    output(["data", "eof"])
+  end
+
+  defp read_opts(%{"handle" => handle}) do
+    opts = %{"handle" => handle}
+
+    if size = Application.get_env(:chromic_pdf, :stream_read_size) do
+      Map.put(opts, "size", size)
+    else
+      opts
+    end
+  end
+end


### PR DESCRIPTION
Closes #136

This patch adds `print_to_pdf_as_stream`, a new PDF printing function
that makes use of the `transferMode: "ReturnAsStream"` option.

Drive-by refactors:

* Simplify `SessionPool` and make it responsible only for session
  checkin/checkout and keeping track of the use count.
* Move the rest of the functionality (spawn protocol, etc.) to `Channel`
  with an API in `Browser`.
* Expose the `checkout_session` function to the API layer so it can use
  it for `print_to_pdf_as_stream` (as that needs to run multiple
  protocols on the same session).
* Dropped the `checkout_and_count` vs. `checkout` thing in favour of simply counting each session use.

## TODOs

- [ ] try it out, see if it does any good
- [ ] refactor `print_to_pdf_as_stream`, move the code somewhere else
- [ ] add tests for `print_to_pdf_as_stream`
- [ ] add an option validation to both functions (forbid `transferMode`)
- [ ] fix the fallout of the `checkout_and_count` removal
- [ ] add to changelog