### PR TITLE
[#153] Possibly incompatible with Ghostscript 9.56.1

### DIFF
--- a/lib/chromic_pdf/pdfa/ghostscript_impl.ex
+++ b/lib/chromic_pdf/pdfa/ghostscript_impl.ex
@@ -20,20 +20,20 @@ defmodule ChromicPDF.GhostscriptImpl do
   @impl ChromicPDF.Ghostscript
   def run_postscript(pdf_path, ps_path) do
     ghostscript_cmd!([
-      ~s(--permit-file-read="#{pdf_path}"),
-      ~s(--permit-file-read="#{ps_path}"),
+      ~s(--permit-file-read=#{pdf_path}),
+      ~s(--permit-file-read=#{ps_path}),
       "-dNODISPLAY",
       "-q",
-      ~s(-sFile="#{pdf_path}"),
-      ~s("#{ps_path}")
+      ~s(-sFile=#{pdf_path}),
+      ps_path
     ])
   end
 
   @impl ChromicPDF.Ghostscript
   def embed_fonts(pdf_path, output_path) do
     ghostscript_cmd!([
-      ~s(--permit-file-read="#{pdf_path}"),
-      ~s(--permit-file-write="#{output_path}"),
+      ~s(--permit-file-read=#{pdf_path}),
+      ~s(--permit-file-write=#{output_path}),
       "-dEmbedAllFonts=true",
       "-dSubsetFonts=true",
       "-dCompressFonts=true",
@@ -45,8 +45,8 @@ defmodule ChromicPDF.GhostscriptImpl do
       "-dAutoFilterColorImages=false",
       "-dAutoFilterGrayImages=false",
       "-sDEVICE=pdfwrite",
-      ~s(-sOutputFile="#{output_path}"),
-      ~s("#{pdf_path}")
+      ~s(-sOutputFile=#{output_path}),
+      ~s(#{pdf_path})
     ])
 
     :ok
@@ -56,20 +56,20 @@ defmodule ChromicPDF.GhostscriptImpl do
   def convert_to_pdfa(pdf_path, pdfa_version, icc_path, pdfa_def_ps_path, output_path)
       when pdfa_version in ["2", "3"] do
     ghostscript_cmd!([
-      ~s(--permit-file-read="#{pdf_path}"),
-      ~s(--permit-file-read="#{icc_path}"),
-      ~s(--permit-file-read="#{pdfa_def_ps_path}"),
-      ~s(--permit-file-write="#{output_path}"),
+      ~s(--permit-file-read=#{pdf_path}),
+      ~s(--permit-file-read=#{icc_path}),
+      ~s(--permit-file-read=#{pdfa_def_ps_path}),
+      ~s(--permit-file-write=#{output_path}),
       "-dPDFA=#{pdfa_version}",
       # http://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff;h=094d5a1880f1cb9ed320ca9353eb69436e09b594
       "-dPDFACompatibilityPolicy=1",
       "-sProcessColorModel=DeviceRGB",
       "-sColorConversionStrategy=RGB",
-      ~s(-sOutputICCProfile="#{icc_path}"),
+      ~s(-sOutputICCProfile=#{icc_path}),
       "-sDEVICE=pdfwrite",
-      ~s(-sOutputFile="#{output_path}"),
-      ~s("#{pdf_path}"),
-      ~s("#{pdfa_def_ps_path}")
+      ~s(-sOutputFile=#{output_path}),
+      ~s(#{pdf_path}),
+      ~s(#{pdfa_def_ps_path})
     ])
 
     :ok

--- a/test/integration/pdfa_generation_test.exs
+++ b/test/integration/pdfa_generation_test.exs
@@ -1,6 +1,6 @@
 defmodule ChromicPDF.PDFAGenerationTest do
   use ExUnit.Case, async: false
-  import ChromicPDF.Utils, only: [system_cmd!: 2]
+  import ChromicPDF.Utils, only: [system_cmd!: 2, with_tmp_dir: 1]
 
   @test_html Path.expand("../fixtures/test.html", __ENV__.file)
 
@@ -46,6 +46,20 @@ defmodule ChromicPDF.PDFAGenerationTest do
       receive do
         path -> refute File.exists?(path)
       end
+    end
+
+    test "works with file names that need shell escaping" do
+      with_tmp_dir(fn tmp_dir ->
+        pdf_path = Path.join(tmp_dir, "output !@#$%.pdf")
+        pdfa_path = Path.join(tmp_dir, "output* !@#$%.pdf")
+
+        [content: "<p>Test</p>"]
+        |> ChromicPDF.Template.source_and_options()
+        |> ChromicPDF.print_to_pdf(output: pdf_path)
+
+        ChromicPDF.convert_to_pdfa(pdf_path, output: pdfa_path)
+        assert File.exists?(pdfa_path)
+      end)
     end
 
     @info_opts %{


### PR DESCRIPTION
https://hexdocs.pm/elixir/1.12/System.html#cmd/3

> arguments do not need to be escaped or quoted for shell safety

The arguments seem to confuse `ghostscript`