### PR TITLE
Add another known cause of crashing in Docker containers

### DIFF
--- a/lib/chromic_pdf/pdf/protocol.ex
+++ b/lib/chromic_pdf/pdf/protocol.ex
@@ -132,6 +132,7 @@ defmodule ChromicPDF.Protocol do
       Known causes:
 
       1) External URLs in `<link>` tags in the header/footer templates cause Chrome to crash.
+      2) Shared memory exhaustion causes Chrome to crash. Docker containers only have 64 MB by default available in /dev/shm. Pass --disable-dev-shm-usage as a Chrome flag to use /tmp for this purpose instead, or increase the amount of shared memory available to the container with --shm-size.
       """)
     end
   end

--- a/lib/chromic_pdf/pdf/protocol.ex
+++ b/lib/chromic_pdf/pdf/protocol.ex
@@ -132,7 +132,7 @@ defmodule ChromicPDF.Protocol do
       Known causes:
 
       1) External URLs in `<link>` tags in the header/footer templates cause Chrome to crash.
-      2) Shared memory exhaustion causes Chrome to crash. Docker containers only have 64 MB by default available in /dev/shm. Pass --disable-dev-shm-usage as a Chrome flag to use /tmp for this purpose instead, or increase the amount of shared memory available to the container with --shm-size.
+      2) Shared memory exhaustion can cause Chrome to crash. Depending on your environment, the available shared memory at /dev/shm may be too small for your use-case. This may especially affect you if you run ChromicPDF in a container, as, for instance, the Docker runtime provides only 64 MB to containers by default. Pass --disable-dev-shm-usage as a Chrome flag to use /tmp for this purpose instead (via the `chrome_args` option), or increase the amount of shared memory available to the container (see --shm-size for Docker).
       """)
     end
   end


### PR DESCRIPTION
Hi there, recently I investigated an issue where, under stress, Chromium spawned by ChromicPDF would crash inside of the Docker container.

I eventually found that the `--disable-dev-shm-usage` flag fixes the issue. By default Docker containers have 64 MB of shared memory available in /dev/shm, so under stress, this shared memory is exhausted, and Chromium crashes: https://github.com/puppeteer/puppeteer/blob/v1.0.0/docs/troubleshooting.md#tips

`--disable-dev-shm-usage` fixes this by using /tmp instead, at the cost of potentially reduced performance since in most configurations /tmp will be disk I/O bound of course.

It may be worth adding this flag to the ChromicPDF API as an option, like with `no_sandbox`. But due to the performance concerns, whether this should be default or not is up for debate.