### PR TITLE
Add a disable_scripts navigation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-- Add disable_scripts option to `print_to_pdf/2`. 
+- Add disable_scripts option to `print_to_pdf/2`. See the security section of `lib/chromic_pdf.ex` for more details
 ## [1.2.2] - 2022-07-18
 
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+### Added
+- Add disable_scripts option to `print_to_pdf/2`. 
 ## [1.2.2] - 2022-07-18
 
 ### Fixed 

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -57,7 +57,7 @@ defmodule ChromicPDF do
       end
 
   ### Disabling scripts
-  
+
   Scripts are the biggest attack vector in a browser, potentially leading to many different
   exploits in case of XSS, such as SSRF or even code execution in case of a v8 exploit. 
   They can be disabled using the DevTools command [Emulation.setScriptExecutionDisabled](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setScriptExecutionDisabled).

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -56,6 +56,18 @@ defmodule ChromicPDF do
         [offline: true]
       end
 
+  ### Disabling scripts
+  
+  Scripts are the biggest attack vector in a browser, potentially leading to many different
+  exploits in case of XSS, such as SSRF or even code execution in case of a v8 exploit. 
+  They can be disabled using the DevTools command [Emulation.setScriptExecutionDisabled](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setScriptExecutionDisabled).
+  Note that this doesn't prevent other features, like the `evaluate` option from working,
+  it simply prevents scripts from being executed on the page.
+
+      def chromic_pdf_opts do
+        [disable_scripts: true]
+      end
+
   ### Chrome Sandbox in Docker containers
 
   By default, ChromicPDF will allow Chrome to make use of its own ["sandbox" process jail](https://chromium.googlesource.com/chromium/src/+/master/docs/design/sandbox.md).

--- a/lib/chromic_pdf/pdf/protocols/navigate.ex
+++ b/lib/chromic_pdf/pdf/protocols/navigate.ex
@@ -6,6 +6,17 @@ defmodule ChromicPDF.Navigate do
   import ChromicPDF.ProtocolMacros
 
   steps do
+    if_option :disable_scripts do
+      call(
+        :disable_scripts,
+        "Emulation.setScriptExecutionDisabled",
+        [{"value", :disable_scripts}],
+        %{}
+      )
+
+      await_response(:scripts_disabled, [])
+    end
+
     if_option :set_cookie do
       call(:set_cookie, "Network.setCookie", &Map.fetch!(&1, :set_cookie), %{})
       await_response(:cookie_set, [])

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -183,6 +183,7 @@ defmodule ChromicPDF.Supervisor do
 
       @type navigate_option ::
               {:set_cookie, map()}
+              | {:disable_scripts, boolean()}
               | evaluate_option()
               | wait_for_option()
 

--- a/test/integration/fixtures/test_dynamic.html
+++ b/test/integration/fixtures/test_dynamic.html
@@ -7,6 +7,7 @@
 <body>
   <div id="dynamic"></div>
   <div id="print-ready"></div>
+  <noscript>Javascript is disabled</noscript>
 
   <script>
     function loadDynamicContent() {

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -224,6 +224,30 @@ defmodule ChromicPDF.PDFGenerationTest do
         assert String.contains?(text, "Dynamic content from Javascript")
       end)
     end
+
+    @tag :pdftotext
+    test "it renders noscript tags when given disable_scripts: true" do
+      params = [
+        disable_scripts: true
+      ]
+
+      print_to_pdf({:url, "file://#{@test_dynamic_html}"}, params, fn text ->
+        assert String.contains?(text, "Javascript is disabled")
+        assert !String.contains?(text, "Dynamic content from Javascript")
+      end)
+    end
+
+    @tag :pdftotext
+    test "it can evaluate scripts with disable_scripts: true" do
+      params = [
+        evaluate: %{expression: @script},
+        disable_scripts: true
+      ]
+
+      print_to_pdf({:html, File.read!(@test_html)}, params, fn text ->
+        assert String.contains?(text, "hello from script")
+      end)
+    end
   end
 
   describe "offline mode" do


### PR DESCRIPTION
This is useful for security, preventing exploitation of v8 bugs, SSRF and many other potential issues.

An alternative to this implementation(calling `Emulation.setScriptExecutionDisabled`) that can be used with the current version of chromic_pdf is to set the chromium flag `--blink-settings=scriptEnabled=false`, but because of the lack of stability or documentation of chromium cmdline flags I think this is a way better solution.