### PR TITLE
Change page size assertion to match newer Chrome files

### DIFF
--- a/test/integration/template_test.exs
+++ b/test/integration/template_test.exs
@@ -63,7 +63,9 @@ defmodule ChromicPDF.TemplateTest do
       print_to_pdf(pdf_params, fn _text ->
         output = system_cmd!("pdfinfo", [@output])
 
-        assert output =~ ~r/Page size:\s+597.12 x 841.92 pts/
+        # Older Chrome/Skia versions calculated slightly lower pts from the 8.3 inch width.
+        # Older versions were not detected as A4 by pdfinfo.
+        assert output =~ ~r/Page size:\s+(597\.12|598\.08) x 841\.92 pts( \(A4\))?/
       end)
     end
 
@@ -78,7 +80,7 @@ defmodule ChromicPDF.TemplateTest do
       print_to_pdf(pdf_params, fn _text ->
         output = system_cmd!("pdfinfo", [@output])
 
-        assert output =~ ~r/Page size:\s+841.92 x 597.12 pts/
+        assert output =~ ~r/Page size:\s+841\.92 x (597\.12|598\.08) pts/
       end)
     end
   end


### PR DESCRIPTION
This patch changes the page size assertion for our `size: :a4` test, as more recent Chrome/Skia versions generate slightly wider pages. 

To exactly pinpoint which version of Chrome brought the change, I'd need to bisect Chrome versions, but TBH I don't think we gain much from the information.

## Example

Both of these files were generated by the same command and analyzed using the same `pdfinfo` machine (on my host):

```elixir
[content: "<p>Hello</p>", size: :a4]
|> ChromicPDF.Template.source_and_options()
|> ChromicPDF.print_to_pdf(output: "file.pdf")
```

| Chrome |File | pdfinfo | Screenshot |
| - | -| -| -|
| v90 | [chrome90.pdf](https://github.com/bitcrowd/chromic_pdf/files/10148590/chrome90.pdf) | ![image](https://user-images.githubusercontent.com/96114/205493499-46482a1f-e08c-4f5e-b4a0-b89cfa7dfe2c.png) | ![image](https://user-images.githubusercontent.com/96114/205493511-1abba33f-c36d-492f-8a53-7caff4e4fd61.png) |
| v108 | [chrome108.pdf](https://github.com/bitcrowd/chromic_pdf/files/10148592/chrome108.pdf) | ![image](https://user-images.githubusercontent.com/96114/205493549-de12db6b-2a47-4feb-be12-156c1b0ae3ed.png) | ![image](https://user-images.githubusercontent.com/96114/205493569-de0387ac-01ee-4c81-8db9-0e450131b222.png) |

### On the "A4" detection of pdfinfo

My recent local `pdfinfo` detects both sizes as "A4" (by adding the `" (A4)"` suffix to the `Page size` line). The `pdfinfo` in our CI image apprently is older and does not detect the 597.12pts width as A4, hence I made it optional.

### On the file size

Also noteworthy that the file size is significantly lower in the v108-generated one, though that could be caused by a different default font being chosen on my machine vs. the docker container where I generated the v90 one. Apparently the font on my host is not embedded into the PDF? ~~Could also be a bug that more recent Chrome's don't embed the fonts anymore oO~~ (see below)

## What do we make of this

It looks like Chrome adjusted their calculation from inch to points slightly. Perhaps even to please `pdfinfo`, but probably not.

Interestingly, if you ask the internet about "A4 size in points", you get varying answers, but mostly it is said that A4 is "usually rounded to 595 x 842pts" ([here](https://www.prepressure.com/library/paper-size/din-a4) but also [here](https://www.a4-size.com/a4-size-in-point/)). I don't really understand why: A4 is defined as 210x297mm or 8.3x11.7" ([ISO 216](https://en.wikipedia.org/wiki/ISO_216)). For the point, wikipedia claims it has a de-facto standard of 1/72inch ([Point](https://en.wikipedia.org/wiki/Point_(typography))), so this would translate precisely to `8.3 / (1/72) = 597.6`. I conclude something else must be going on with the Point in Chrome/Skia. 

Overall, it doesn't matter a single bit to the user, I would think. A point is very small. 🤷