### PR TITLE
Reduce resource waste in test

### DIFF
--- a/test/integration/session_pool_test.exs
+++ b/test/integration/session_pool_test.exs
@@ -52,13 +52,13 @@ defmodule ChromicPDF.SessionPoolTest do
     test "can be configured and generates a nice error messages" do
       err =
         capture_log(fn ->
-          start_supervised!({ChromicPDF, session_pool: [init_timeout: 1]})
+          start_supervised!({ChromicPDF, session_pool: [init_timeout: 10]})
           # wait for nimble pool to init
           :timer.sleep(100)
         end)
 
       assert err =~ "Timeout in Channel.run_protocol"
-      assert err =~ "within the configured\n1 milliseconds"
+      assert err =~ "within the configured\n10 milliseconds"
       assert err =~ "%ChromicPDF.Protocol{"
       assert err =~ "SpawnSession"
     end


### PR DESCRIPTION
```
Since this test is configured to fail after a very short `init_timeout`,
NimblePool tries to restart the service a bunch of times, each time
sending a `createBrowserContext` message to Chrome.

This patch increases the timeout to 10ms, so at least we don't create a
hundred of them, but maybe 10 or so.
```

Open for better solutions on how to fix this