### PR TITLE
Add more default command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Add error details on failure to checkout worker from pool.
+- Add a whole list of new default command line options following Puppeteer's example.
 
 ### Changed
 

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -4,6 +4,7 @@ defmodule ChromicPDF.PDFGenerationTest do
   use ExUnit.Case, async: false
   import ExUnit.CaptureLog
   import ChromicPDF.TestAPI
+  import ChromicPDF.Utils, only: [system_cmd!: 2]
   alias ChromicPDF.TestServer
 
   setup context do
@@ -195,6 +196,14 @@ defmodule ChromicPDF.PDFGenerationTest do
 
       print_to_pdf({:html, test_dynamic_html()}, params, fn text ->
         assert String.contains?(text, "Dynamic content from Javascript")
+      end)
+    end
+
+    @tag :pdfinfo
+    test "generated PDFs are tagged" do
+      with_output_path(fn output ->
+        assert ChromicPDF.print_to_pdf({:html, test_html()}, output: output) == :ok
+        assert system_cmd!("pdfinfo", [output]) =~ ~r/Tagged:\s+yes/
       end)
     end
   end

--- a/test/integration/pdfa_generation_test.exs
+++ b/test/integration/pdfa_generation_test.exs
@@ -100,5 +100,15 @@ defmodule ChromicPDF.PDFAGenerationTest do
         assert output =~ ~r/Title:\s+OverriddenTitle/
       end)
     end
+
+    @tag :pdfinfo
+    # pdfwrite does not copy the structural metadata from the input PDF to the output.
+    # https://stackoverflow.com/q/69299263
+    test "unfortunately converted PDFs are not tagged anymore" do
+      print_to_pdfa([], fn file ->
+        output = system_cmd!("pdfinfo", [file])
+        assert output =~ ~r/Tagged:\s+no/
+      end)
+    end
   end
 end

--- a/test/integration/support/test_api.ex
+++ b/test/integration/support/test_api.ex
@@ -47,13 +47,13 @@ defmodule ChromicPDF.TestAPI do
   end
 
   def print_to_pdf(input, pdf_params, cb) do
-    assert ChromicPDF.print_to_pdf(input, Keyword.put(pdf_params, :output, @output)) == :ok
-    assert File.exists?(@output)
+    with_output_path(fn output ->
+      assert ChromicPDF.print_to_pdf(input, Keyword.put(pdf_params, :output, output)) == :ok
+      assert File.exists?(output)
 
-    text = system_cmd!("pdftotext", [@output, "-"])
-    cb.(text)
-  after
-    File.rm_rf!(@output)
+      text = system_cmd!("pdftotext", [output, "-"])
+      cb.(text)
+    end)
   end
 
   def print_to_pdf_delayed(delay_ms) do
@@ -67,5 +67,11 @@ defmodule ChromicPDF.TestAPI do
       },
       wait_for: %{selector: "#print-ready", attribute: "ready-to-print"}
     )
+  end
+
+  def with_output_path(fun) do
+    fun.(@output)
+  after
+    File.rm_rf!(@output)
   end
 end


### PR DESCRIPTION
    This patch extends our list of default command line argument passed
    to Chrome based on Puppeteer's example.