### PR TITLE
Adds an example how to pass `print_to_pdf` options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Here's how you generate a PDF from an external URL and store it in the local fil
 ChromicPDF.print_to_pdf({:url, "https://example.net"}, output: "example.pdf")
 ```
 
+And here's how you pass options to [Chrome DevTools' `printToPDF`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF) function:
+
+```elixir
+ChromicPDF.print_to_pdf({:url, "https://example.net"}, output: "example.pdf", print_to_pdf: %{marginTop: 0})
+```
+
 The next example shows how to print a local HTML file to PDF/A, as well as the use of a callback
 function that receives the generated PDF as path to a temporary file.
 


### PR DESCRIPTION
Just a small docs improvement adding an example how to pass `print_to_pdf` options to Chrome DevTools. I had to dig it in the sources, so it may save time someone.

Thanks for building this package, it saved me a ton of hassle!

