### PR TITLE
Extract t:export_option from t:pdf_option

### DIFF
--- a/lib/chromic_pdf/api.ex
+++ b/lib/chromic_pdf/api.ex
@@ -18,8 +18,8 @@ defmodule ChromicPDF.API do
   @spec print_to_pdf(
           ChromicPDF.Supervisor.services(),
           ChromicPDF.source() | ChromicPDF.source_and_options(),
-          [ChromicPDF.pdf_option()]
-        ) :: ChromicPDF.return()
+          [ChromicPDF.pdf_option() | ChromicPDF.export_option()]
+        ) :: ChromicPDF.export_return()
   def print_to_pdf(services, %{source: source, opts: opts}, overrides)
       when tuple_size(source) == 2 and is_list(opts) and is_list(overrides) do
     print_to_pdf(services, source, Keyword.merge(opts, overrides))
@@ -30,9 +30,9 @@ defmodule ChromicPDF.API do
   end
 
   @spec capture_screenshot(ChromicPDF.Supervisor.services(), ChromicPDF.source(), [
-          ChromicPDF.capture_screenshot_option()
+          ChromicPDF.capture_screenshot_option() | ChromicPDF.export_option()
         ]) ::
-          ChromicPDF.return()
+          ChromicPDF.export_return()
   def capture_screenshot(services, source, opts) when tuple_size(source) == 2 and is_list(opts) do
     chrome_export(services, :capture_screenshot, source, opts)
   end
@@ -53,9 +53,9 @@ defmodule ChromicPDF.API do
   end
 
   @spec convert_to_pdfa(ChromicPDF.Supervisor.services(), ChromicPDF.path(), [
-          ChromicPDF.pdfa_option()
+          ChromicPDF.pdfa_option() | ChromicPDF.export_option()
         ]) ::
-          ChromicPDF.return()
+          ChromicPDF.export_return()
   def convert_to_pdfa(services, pdf_path, opts) when is_binary(pdf_path) and is_list(opts) do
     with_tmp_dir(fn tmp_dir ->
       do_convert_to_pdfa(services, pdf_path, opts, tmp_dir)
@@ -66,10 +66,10 @@ defmodule ChromicPDF.API do
           ChromicPDF.Supervisor.services(),
           ChromicPDF.source() | ChromicPDF.source_and_options(),
           [
-            ChromicPDF.pdf_option() | ChromicPDF.pdfa_option()
+            ChromicPDF.pdf_option() | ChromicPDF.pdfa_option() | ChromicPDF.export_option()
           ]
         ) ::
-          ChromicPDF.return()
+          ChromicPDF.export_return()
   def print_to_pdfa(services, %{source: source, opts: opts}, overrides)
       when tuple_size(source) == 2 and is_list(opts) and is_list(overrides) do
     print_to_pdfa(services, source, Keyword.merge(opts, overrides))

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -156,9 +156,13 @@ defmodule ChromicPDF.Supervisor do
       @type output_function :: (blob() -> output_function_result())
       @type output_option :: {:output, binary()} | {:output, output_function()}
 
-      @type return :: :ok | {:ok, binary()} | {:ok, output_function_result()}
-
       @type telemetry_metadata_option :: {:telemetry_metadata, map()}
+
+      @type export_option ::
+              output_option()
+              | telemetry_metadata_option()
+
+      @type export_return :: :ok | {:ok, binary()} | {:ok, output_function_result()}
 
       @type info_option ::
               {:info,
@@ -189,21 +193,15 @@ defmodule ChromicPDF.Supervisor do
       @type pdf_option ::
               {:print_to_pdf, map()}
               | navigate_option()
-              | output_option()
-              | telemetry_metadata_option()
 
       @type pdfa_option ::
               {:pdfa_version, binary()}
               | {:pdfa_def_ext, binary()}
               | info_option()
-              | output_option()
-              | telemetry_metadata_option()
 
       @type capture_screenshot_option ::
               {:capture_screenshot, map()}
               | navigate_option()
-              | output_option()
-              | telemetry_metadata_option()
 
       @type session_pool_option ::
               {:size, non_neg_integer()}
@@ -505,8 +503,8 @@ defmodule ChromicPDF.Supervisor do
       '''
       @spec print_to_pdf(
               input :: source() | source_and_options(),
-              opts :: [pdf_option()]
-            ) :: return()
+              opts :: [pdf_option() | export_option()]
+            ) :: export_return()
       def print_to_pdf(input, opts \\ []) do
         with_services(__MODULE__, &API.print_to_pdf(&1, input, opts))
       end
@@ -534,7 +532,10 @@ defmodule ChromicPDF.Supervisor do
 
       For navigational options (source, cookies, evaluating scripts) see `print_to_pdf/2`.
       """
-      @spec capture_screenshot(url :: source(), opts :: [capture_screenshot_option()]) :: return()
+      @spec capture_screenshot(
+              url :: source(),
+              opts :: [capture_screenshot_option() | export_option()]
+            ) :: export_return()
       def capture_screenshot(input, opts \\ []) do
         with_services(__MODULE__, &API.capture_screenshot(&1, input, opts))
       end
@@ -597,7 +598,7 @@ defmodule ChromicPDF.Supervisor do
             pdfa_def_ext: "[/Title (OverriddenTitle) /DOCINFO pdfmark",
           )
       """
-      @spec convert_to_pdfa(pdf_path :: path(), opts :: [pdfa_option()]) :: return()
+      @spec convert_to_pdfa(pdf_path :: path(), opts :: [pdfa_option()]) :: export_return()
       def convert_to_pdfa(pdf_path, opts \\ []) do
         with_services(__MODULE__, &API.convert_to_pdfa(&1, pdf_path, opts))
       end
@@ -613,8 +614,8 @@ defmodule ChromicPDF.Supervisor do
       """
       @spec print_to_pdfa(
               input :: source() | source_and_options(),
-              opts :: [pdf_option() | pdfa_option()]
-            ) :: return()
+              opts :: [pdf_option() | pdfa_option() | export_option()]
+            ) :: export_return()
       def print_to_pdfa(input, opts \\ []) do
         with_services(__MODULE__, &API.print_to_pdfa(&1, input, opts))
       end


### PR DESCRIPTION
This patch slightly rearranges our parameter types to separate the export-specific options (output, telemetry) from the PDF printing-specific options.