### PR TITLE
[#219] Handle DOWN in terminate_worker/3

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,7 +7,7 @@ jobs:
       MIX_ENV: test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/bitcrowd/chromic_pdf-test-image:debian-bullseye
+      image: ghcr.io/bitcrowd/chromic_pdf:debian-bullseye
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+- Handle `DOWN` reason in `SessionPool.terminate_worker/3` callback. Fixes [#219](https://github.com/bitcrowd/chromic_pdf/issues/219).
+
 ## [1.6.0] - 2023-01-12
 
 ### Fixed

--- a/lib/chromic_pdf/pdf/browser/session_pool.ex
+++ b/lib/chromic_pdf/pdf/browser/session_pool.ex
@@ -188,8 +188,9 @@ defmodule ChromicPDF.Browser.SessionPool do
   # Reasons we want to gracefully clean up the target in the Browser:
   # - max_session_uses_reached, our own mechanism for keeping memory bloat in check
   # - error, when an exception is raised in the Channel
+  # - DOWN, client link is broken (reported by a user as "this happens")
   def terminate_worker(reason, worker_state, pool_state)
-      when reason in [:max_session_uses_reached, :error] do
+      when reason in [:max_session_uses_reached, :error, :DOWN] do
     Task.async(fn ->
       protocol = CloseTarget.new(targetId: worker_state.session.target_id)
 
@@ -208,5 +209,5 @@ defmodule ChromicPDF.Browser.SessionPool do
     {:ok, pool_state}
   end
 
-  # Unexpected other terminate reasons: :DOWN | :timeout | :throw | :exit
+  # Unexpected other terminate reasons: :timeout | :throw | :exit
 end


### PR DESCRIPTION
This patch handles the `DOWN` reason in the `terminate_worker/3` callback, which we previously thought "would not happen", but a user reported it as "does happen indeed". Not 100% sure how or why it happens, but we don't expect anything to break if we handle it.

Fixes [#219](https://github.com/bitcrowd/chromic_pdf/issues/219)