### PR TITLE
compability with Elixir versions below  1.12 

### DIFF
--- a/lib/chromic_pdf/pdf/protocol.ex
+++ b/lib/chromic_pdf/pdf/protocol.ex
@@ -151,10 +151,13 @@ defmodule ChromicPDF.Protocol do
     }
 
     def inspect(%ChromicPDF.Protocol{} = protocol, opts) do
-      protocol
-      |> Map.from_struct()
-      |> filter(@allowed_values)
-      |> then(fn map -> struct!(ChromicPDF.Protocol, map) end)
+      map =
+        protocol
+        |> Map.from_struct()
+        |> filter(@allowed_values)
+
+      ChromicPDF.Protocol
+      |> struct!(map)
       |> Inspect.Any.inspect(opts)
     end
 


### PR DESCRIPTION
Hey there,

Since Elixir version requirement isn't specified, I'd love to make the latest version of the lib compatible with versions below 1.12, where Kernel.then was introduced.

Removing it was enough to make the lib compile using at least Elixir 1.11, haven't tried another versions.

Consider 1.10 almost deprecated https://hexdocs.pm/elixir/compatibility-and-deprecations.html

By the way, first PR in Open Source project, so let me know if something isn't right :)