### PR TITLE
Enable Elixir 1.11 test image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,12 +5,12 @@ jobs:
     name: ${{ matrix.tag }}
     strategy:
       matrix:
-        tag: ['debian-buster', 'debian-bullseye', 'alpine-3-16-2', 'alpine-3-17-0']
+        tag: ['elixir-1-11', 'debian-buster', 'debian-bullseye', 'alpine-3-16-2', 'alpine-3-17-0']
     env:
       MIX_ENV: test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/bitcrowd/chromic_pdf-test-image:${{ matrix.tag }}
+      image: ghcr.io/bitcrowd/chromic_pdf:${{ matrix.tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,8 +17,18 @@ ChromicPDF is a HTML-to-PDF renderer for Elixir, based on headless Chrome.
 
 ## Requirements
 
-* Chromium or Chrome
-* Ghostscript (optional, for PDF/A support and concatenation of multiple sources)
+- Chromium or Chrome
+- Ghostscript (optional, for PDF/A support and concatenation of multiple sources)
+
+ChromicPDF is tested in the following configurations:
+
+| Elixir | Erlang/OTP | Distribution    | Chromium        | Ghostscript |
+| ------ | ---------- | --------------- | --------------- | ----------- |
+| 1.14.0 | 25.1       | Alpine 3.17     | 109.0.5414.74   | 10.0.0      |
+| 1.14.0 | 25.1       | Alpine 3.16     | 102.0.5005.182  | 9.56.1      |
+| 1.14.0 | 25.1       | Debian Bullseye | 108.0.5359.94   | 9.53.3      |
+| 1.14.0 | 25.1       | Debian Buster   | 90.0.4430.212-1 | 9.27        |
+| 1.11.4 | 22.3.4.26  | Debian Buster   | 90.0.4430.212-1 | 9.27        |
 
 ## Installation
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule ChromicPdf.MixProject do
     [
       app: :chromic_pdf,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       dialyzer: [plt_add_apps: [:ex_unit, :mix], plt_file: {:no_warn, ".plts/dialyzer.plt"}],
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
    - Enable Elixir 1.11 test image
    - Fix broken image repo (`-test-image`) in test workflow
    - Set minimum required Elixir version to 1.11
    - Document test matrix in README