### PR TITLE
Add :raise_on_unhandled_runtime_exceptions option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Add `unhandled_runtime_exceptions` option that allows to raise on unhandled JavaScript exceptions in templates. Default to warn about them in log.
+
 ### Changed
 
 - Simplified `on_demand` mode. Instead of spawning the entire supervision tree temporarily, we now only spawn the `Browser` process. Also instead of giving the normal `ChromicPDF` name to the temporary supervisor, which effectively prevented concurrent access to ChromicPDF when configured with `on_demand: true`, the temporary `Browser` process remains anonymous.

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -287,6 +287,19 @@ defmodule ChromicPDF do
 
   * `[:chromic_pdf, :join_pdfs, :start | :stop | exception]`
 
+  ## Further options
+
+  ### Debugging unhandled runtime exceptions
+
+  By default, runtime exceptions thrown in JavaScript execution contexts are logged. You may
+  choose to instead convert them into an Elixir exception by passing the following option:
+
+      defp chromic_pdf_opts do
+        [unhandled_runtime_exceptions: :raise]
+      end
+
+  Alternatively, you can pass `:ignore` to silence the log statement.
+
   ## On Accessibility / PDF/UA
 
   Since its version 85, Chrome generates "Tagged PDF" files [by

--- a/lib/chromic_pdf/api/chrome_error.ex
+++ b/lib/chromic_pdf/api/chrome_error.ex
@@ -16,6 +16,10 @@ defmodule ChromicPDF.ChromeError do
     """
   end
 
+  defp title_for_error({:exception_thrown, _error}) do
+    "Unhandled exception in JS runtime"
+  end
+
   defp title_for_error({:evaluate, _error}) do
     "Exception in :evaluate expression"
   end
@@ -44,6 +48,16 @@ defmodule ChromicPDF.ChromeError do
     can disable certificate verification by passing the `:ignore_certificate_errors` flag.
 
         {ChromicPDF, ignore_certificate_errors: true}
+    """
+  end
+
+  defp hint_for_error({:exception_thrown, error}, _opts) do
+    %{"exception" => %{"description" => description}} = error
+
+    """
+    Exception:
+
+    #{indent(description)}
     """
   end
 

--- a/lib/chromic_pdf/pdf/protocols/spawn_session.ex
+++ b/lib/chromic_pdf/pdf/protocols/spawn_session.ex
@@ -43,6 +43,12 @@ defmodule ChromicPDF.SpawnSession do
       # Intentionally not awaiting the response to speed up session spawning.
     end
 
+    # Enable Runtime (JS) events, mostly for Runtime.exceptionThrown.
+    # Again, no need to wait for result.
+    if_option {:unhandled_runtime_exceptions, [:log, :raise]} do
+      call(:runtime_enable, "Runtime.enable", [], %{})
+    end
+
     if_option :disable_scripts do
       call(
         :disable_scripts,

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -201,6 +201,7 @@ defmodule ChromicPDF.Supervisor do
               {:name, atom()}
               | {:offline, boolean()}
               | {:disable_scripts, boolean()}
+              | {:unhandled_runtime_exceptions, :ignore | :log | :raise}
               | {:max_session_uses, non_neg_integer()}
               | {:session_pool, [session_pool_option()]}
               | {:ignore_certificate_errors, boolean()}


### PR DESCRIPTION
This patch adds the `:unhandled_runtime_exceptions` option that allows to configure sessions to raise a ChromeError when Chrome sends us a `Runtime.exceptionThrown` notification.

Relates to #237