### PR TITLE
Gracefully handle errors returned by chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+- Handle errors (for example due to incorrect parameters) returned by Chromium right away [#244](https://github.com/bitcrowd/chromic_pdf/pull/244)
 
 ## [1.8.1] - 2023-04-20 
 

--- a/lib/chromic_pdf/api/chrome_error.ex
+++ b/lib/chromic_pdf/api/chrome_error.ex
@@ -16,10 +16,6 @@ defmodule ChromicPDF.ChromeError do
     """
   end
 
-  defp title_for_error({:error_returned, _error}) do
-    "Chrome returned an error"
-  end
-
   defp title_for_error({:exception_thrown, _error}) do
     "Unhandled exception in JS runtime"
   end
@@ -52,17 +48,6 @@ defmodule ChromicPDF.ChromeError do
     can disable certificate verification by passing the `:ignore_certificate_errors` flag.
 
         {ChromicPDF, ignore_certificate_errors: true}
-    """
-  end
-
-  defp hint_for_error({:error_returned, error}, _opts) do
-    %{"code" => code, "message" => message} = error
-
-    """
-    Error:
-
-    #{indent("Code: #{code}")}
-    #{indent(message)}
     """
   end
 

--- a/lib/chromic_pdf/api/chrome_error.ex
+++ b/lib/chromic_pdf/api/chrome_error.ex
@@ -16,6 +16,10 @@ defmodule ChromicPDF.ChromeError do
     """
   end
 
+  defp title_for_error({:error_returned, _error}) do
+    "Chrome returned an error"
+  end
+
   defp title_for_error({:exception_thrown, _error}) do
     "Unhandled exception in JS runtime"
   end
@@ -48,6 +52,17 @@ defmodule ChromicPDF.ChromeError do
     can disable certificate verification by passing the `:ignore_certificate_errors` flag.
 
         {ChromicPDF, ignore_certificate_errors: true}
+    """
+  end
+
+  defp hint_for_error({:error_returned, error}, _opts) do
+    %{"code" => code, "message" => message} = error
+
+    """
+    Error:
+
+    #{indent("Code: #{code}")}
+    #{indent(message)}
     """
   end
 

--- a/lib/chromic_pdf/pdf/connection/json_rpc.ex
+++ b/lib/chromic_pdf/pdf/connection/json_rpc.ex
@@ -68,10 +68,12 @@ defmodule ChromicPDF.Connection.JsonRPC do
     Map.has_key?(msg, "method") && msg["method"] == method
   end
 
-  def is_error_message?(msg) do
+  @spec is_error?(message()) :: boolean()
+  def is_error?(msg) do
     Map.has_key?(msg, "error")
   end
 
+  @spec extract_error(message()) :: String.t()
   def extract_error(%{"error" => %{"message" => message, "code" => code}}) do
     "#{message} (Code #{code})"
   end

--- a/lib/chromic_pdf/pdf/connection/json_rpc.ex
+++ b/lib/chromic_pdf/pdf/connection/json_rpc.ex
@@ -74,7 +74,7 @@ defmodule ChromicPDF.Connection.JsonRPC do
   end
 
   @spec extract_error(message()) :: String.t()
-  def extract_error(%{"error" => %{"message" => message, "code" => code}}) do
-    "#{message} (Code #{code})"
+  def extract_error(%{"error" => error}) do
+    "#{error["message"]} (Code #{error["code"]})"
   end
 end

--- a/lib/chromic_pdf/pdf/connection/json_rpc.ex
+++ b/lib/chromic_pdf/pdf/connection/json_rpc.ex
@@ -59,7 +59,8 @@ defmodule ChromicPDF.Connection.JsonRPC do
 
   @spec is_response?(message(), call_id()) :: boolean()
   def is_response?(msg, call_id) do
-    Map.has_key?(msg, "result") && msg["id"] == call_id
+    (Map.has_key?(msg, "result") or Map.has_key?(msg, "error")) and
+      msg["id"] == call_id
   end
 
   @spec is_notification?(message(), method()) :: boolean()
@@ -69,5 +70,9 @@ defmodule ChromicPDF.Connection.JsonRPC do
 
   def is_error_message?(msg) do
     Map.has_key?(msg, "error")
+  end
+
+  def extract_error(%{"error" => %{"message" => message, "code" => code}}) do
+    "#{message} (Code #{code})"
   end
 end

--- a/lib/chromic_pdf/pdf/connection/json_rpc.ex
+++ b/lib/chromic_pdf/pdf/connection/json_rpc.ex
@@ -66,4 +66,8 @@ defmodule ChromicPDF.Connection.JsonRPC do
   def is_notification?(msg, method) do
     Map.has_key?(msg, "method") && msg["method"] == method
   end
+
+  def is_error_message?(msg) do
+    Map.has_key?(msg, "error")
+  end
 end

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -193,7 +193,7 @@ defmodule ChromicPDF.ProtocolMacros do
             function_exported?(__MODULE__, unquote(cb_name), 2) ->
               apply(__MODULE__, unquote(cb_name), [state, msg])
 
-            JsonRPC.is_error_message?(msg) ->
+            JsonRPC.is_error?(msg) ->
               {:error, JsonRPC.extract_error(msg)}
 
             true ->

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -156,9 +156,10 @@ defmodule ChromicPDF.ProtocolMacros do
       @steps {:await, unquote(name), unquote(length(args))}
 
       def unquote(fundef) do
-        with :no_match <- intercept_exception_thrown(unquote_splicing(args)) do
-          unquote(block)
-        else
+        case intercept_exception_thrown(unquote_splicing(args)) do
+          :no_match ->
+            unquote(block)
+
           error ->
             error
         end

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -415,8 +415,8 @@ defmodule ChromicPDF.PDFGenerationTest do
       ]
 
       assert capture_log(fn ->
-               assert_raise ChromicPDF.Browser.ExecutionError,
-                            ~r/Timeout in Channel.run_protocol/,
+               assert_raise ChromicPDF.ChromeError,
+                            ~r/Chrome returned an error/,
                             fn ->
                               ChromicPDF.print_to_pdf({:html, ""}, params)
                             end

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -323,6 +323,19 @@ defmodule ChromicPDF.PDFGenerationTest do
     end
   end
 
+  describe "handle errors returned by chrome" do
+    setup do
+      start_supervised!(ChromicPDF)
+      :ok
+    end
+
+    test "raise nicely formatted errors" do
+      assert_raise ChromicPDF.ChromeError, ~r/Chrome returned an error/, fn ->
+        print_to_pdf({:html, test_html()}, print_to_pdf: %{pageRanges: "2-3"})
+      end
+    end
+  end
+
   describe "a cookie can be set when printing" do
     @cookie %{
       name: "foo",

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -330,7 +330,7 @@ defmodule ChromicPDF.PDFGenerationTest do
     end
 
     test "raise nicely formatted errors" do
-      assert_raise ChromicPDF.ChromeError, ~r/Chrome returned an error/, fn ->
+      assert_raise ChromicPDF.ChromeError, ~r/Page range exceeds page count/, fn ->
         print_to_pdf({:html, test_html()}, print_to_pdf: %{pageRanges: "2-3"})
       end
     end
@@ -416,7 +416,7 @@ defmodule ChromicPDF.PDFGenerationTest do
 
       assert capture_log(fn ->
                assert_raise ChromicPDF.ChromeError,
-                            ~r/Chrome returned an error/,
+                            ~r/Printing failed/,
                             fn ->
                               ChromicPDF.print_to_pdf({:html, ""}, params)
                             end

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -323,13 +323,13 @@ defmodule ChromicPDF.PDFGenerationTest do
     end
   end
 
-  describe "handle errors returned by chrome" do
+  describe "generic handling of protocol response errors" do
     setup do
       start_supervised!(ChromicPDF)
       :ok
     end
 
-    test "raise nicely formatted errors" do
+    test "response errors raise nicely formatted errors" do
       assert_raise ChromicPDF.ChromeError, ~r/Page range exceeds page count/, fn ->
         print_to_pdf({:html, test_html()}, print_to_pdf: %{pageRanges: "2-3"})
       end


### PR DESCRIPTION
Hi!

While playing around with this I noticed that if I pass some arguably invalid options like in the following example, chromic ignores the error sent by Chrome and instead waits for the timeout and then fails with a generic message.

```
ChromicPDF.print_to_pdf({:html, "<h1>Hello,world!</h1>"}, print_to_pdf: %{pageRanges: "2-3"})
```

In the logs you can see that Chrome immediately tells us that the page range argument was faulty.
```
18:12:15.260 [debug] [ChromicPDF] msg out: %{"id" => 23, "method" => "Page.printToPDF", "params" => %{"footerTemplate" => "", "headerTemplate" => "", "pageRanges" => "2-3"}, "sessionId" => "CE865B72566BD21A8272A3F7EEF30EBE"}
18:12:15.262 [debug] [ChromicPDF] msg in: %{"error" => %{"code" => -32000, "message" => "Page range exceeds page count"}, "id" => 23, "sessionId" => "CE865B72566BD21A8272A3F7EEF30EBE"}
18:12:15.262 [debug] [ChromicPDF] msg in: %{"method" => "Page.frameResized", "params" => %{}, "sessionId" => "CE865B72566BD21A8272A3F7EEF30EBE"}
[... about 5 seconds later the error message appears]
** (ChromicPDF.Browser.ExecutionError) Timeout in Channel.run_protocol/3!

The underlying GenServer.call/3 exited with a timeout. This happens when the browser was
not able to complete the current operation (= PDF print job) within the configured
5000 milliseconds.

If you are printing large PDFs and expect long processing times, please consult the
documentation for the `timeout` option of the session pool.

If you are *not* printing large PDFs but your print jobs still time out, this is likely a
bug in ChromicPDF. Please open an issue on the issue tracker.

---

Current protocol:

%ChromicPDF.Protocol{
  steps: [
    await: &ChromicPDF.PrintToPDF.printed/2,
    call: &ChromicPDF.ResetTarget.reset_history/2,
    await: &ChromicPDF.ResetTarget.history_reset/2,
    call: &ChromicPDF.ResetTarget.blank/2,
    await: &ChromicPDF.ResetTarget.blanked/2,
    await: &ChromicPDF.ResetTarget.fsl_after_blank/2,
    output: &ChromicPDF.PrintToPDF.output/1
  ],
  state: %{
    :__protocol__ => ChromicPDF.PrintToPDF,
    :capture_screenshot => %{},
    :html => "[FILTERED]",
    :ignore_certificate_errors => false,
    :last_call_id => 23,
    :name => "[FILTERED]",
    :offline => false,
    :print_to_pdf => %{
      "footerTemplate" => "[FILTERED]",
      "headerTemplate" => "[FILTERED]",
      "pageRanges" => "2-3"
    },
    :source_type => :html,
    :unhandled_runtime_exceptions => "[FILTERED]",
    "frameId" => "43E1D2D96EBAEDF4BB82A95B74DE397A",
    "sessionId" => "CE865B72566BD21A8272A3F7EEF30EBE"
  }
}

    (chromic_pdf 1.8.1) lib/chromic_pdf/pdf/browser/channel.ex:23: ChromicPDF.Browser.Channel.run_protocol/3
    (chromic_pdf 1.8.1) lib/chromic_pdf/pdf/browser/session_pool.ex:115: ChromicPDF.Browser.SessionPool.do_run_protocol/4
    (nimble_pool 1.0.0) lib/nimble_pool.ex:349: NimblePool.checkout!/4
    (chromic_pdf 1.8.1) lib/chromic_pdf/pdf/browser/session_pool.ex:55: ChromicPDF.Browser.SessionPool.run_protocol/3
    (chromic_pdf 1.8.1) lib/chromic_pdf/api.ex:67: anonymous fn/3 in ChromicPDF.API.chrome_export/4
    (chromic_pdf 1.8.1) lib/chromic_pdf/api/telemetry.ex:10: anonymous fn/2 in ChromicPDF.Telemetry.with_telemetry/3
    (telemetry 1.1.0) /Users/bernhardhackl/src/chromic_pdf/deps/telemetry/src/telemetry.erl:320: :telemetry.span/3
    iex:4: (file)
18:12:20.252 [debug] [ChromicPDF] msg out: %{"id" => 24, "method" => "Target.closeTarget", "params" => %{targetId: "43E1D2D96EBAEDF4BB82A95B74DE397A"}}
```

This PR fixes this and instead of waiting for a timeout handles errors sent via rpc right away.
There's one failing test, but as far as I can tell we should rewrite the test as it basically tests for the behaviour that I fixed here.
