### PR TITLE
Replace deprecated `Logger.warn/1` on Elixir 1.15.0

### DIFF
--- a/lib/chromic_pdf/pdf/browser/session_pool.ex
+++ b/lib/chromic_pdf/pdf/browser/session_pool.ex
@@ -186,7 +186,7 @@ defmodule ChromicPDF.Browser.SessionPool do
   def terminate_worker(reason, worker_state, pool_state)
       when reason in [:max_session_uses_reached, :error, :DOWN] do
     if reason == :DOWN do
-      Logger.warn("""
+      Logger.warning("""
       ChromicPDF received a :DOWN message from the process that called `print_to_pdf/2`!
 
       This means that the process was terminated externally. For instance, your HTTP server

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -241,7 +241,7 @@ defmodule ChromicPDF.ProtocolMacros do
           :no_match
 
         :log ->
-          Logger.warn("""
+          Logger.warning("""
           [ChromicPDF] Unhandled exception in JS runtime
 
           #{get_in!(exception, ["exception", "description"])}


### PR DESCRIPTION
with `Logger.warning/1` (available since Elixir 1.11.0)