### PR TITLE
Document fixes for font render issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+- Document fixes for font rendering issues, and give `ChromicPDF.Template` a `text_rendering` option to allow applying `text-rendering: geometricPrecision;` on all elements.
+
 ## [1.11.0] - 2024-06-19
 
 ### Added

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -257,6 +257,15 @@ defmodule ChromicPDF do
         [chrome_executable: "/usr/bin/google-chrome-beta"]
       end
 
+  ### Font rendering issues on Linux
+
+  On Linux, Chrome and its rendering engine Skia have longstanding issues with rendering certain fonts for print media, especially with regards to letter kerning. See [this issue](https://github.com/puppeteer/puppeteer/issues/2410) in puppeteer for a discussion. If your documents suffer from incorrectly spaced letters, you can try some of the following:
+
+  - Apply the `text-rendering: geometricPrecision` CSS rule. In our tests, this has shown to be the most reliable option. Besides, it is also the most flexible option as you can apply it to individual elements depending on the font-face they use. Recommended.
+  - Set `--font-render-hinting=none` or `--disable-font-subpixel-positioning` command line switches (see `:chrome_args` option above). While this generally improved text rendering in all our tests, it is a bit of a mallet method.
+
+  See also [this blog post](https://www.browserless.io/blog/2020/09/30/puppeteer-print/) for more hints.
+
   ### Debugging Chrome errors
 
   Chrome's stderr logging is silently discarded to not obscure your logfiles. In case you would

--- a/lib/chromic_pdf/template.ex
+++ b/lib/chromic_pdf/template.ex
@@ -60,6 +60,7 @@ defmodule ChromicPDF.Template do
           | {:footer_font_size, binary()}
           | {:footer_zoom, binary()}
           | {:webkit_print_color_adjust, binary()}
+          | {:text_rendering, binary()}
           | {:landscape, boolean()}
 
   @paper_sizes_in_inch %{
@@ -204,6 +205,7 @@ defmodule ChromicPDF.Template do
   <style>
     * {
       -webkit-print-color-adjust: <%= @webkit_print_color_adjust %>;
+      text-rendering: <%= @text_rendering %>;
     }
 
     @page {
@@ -276,7 +278,8 @@ defmodule ChromicPDF.Template do
       footer_font_size: Keyword.get(opts, :footer_font_size, "10pt"),
       header_zoom: Keyword.get(opts, :header_zoom, "0.75"),
       footer_zoom: Keyword.get(opts, :footer_zoom, "0.75"),
-      webkit_print_color_adjust: Keyword.get(opts, :webkit_print_color_adjust, "exact")
+      webkit_print_color_adjust: Keyword.get(opts, :webkit_print_color_adjust, "exact"),
+      text_rendering: Keyword.get(opts, :text_rendering, "auto")
     ]
 
     render_styles(assigns)


### PR DESCRIPTION
This patch adds some documentation to guide people through the inevitable font rendering issues on Linux.

On Linux, Skia has issues rendering certain fonts, it especially completely messes up font kerning. Mitigations exist in the outlined options, yet we decided not to apply any by default, in order not to break any existing templates.

Also added a new `text_rendering` option to `ChromicPDF.Template` to allow easily setting that CSS rule on `*` elements.

## References

- https://github.com/puppeteer/puppeteer/issues/2410
- https://www.browserless.io/blog/2020/09/30/puppeteer-print/
- https://css-tricks.com/almanac/properties/t/text-rendering/
- https://sonneiltech.com/2020/12/manage-your-websites-legibility-using-text-rendering-and-its-alternatives/

## Tests

### Setup

Below you can see test rendering of the same input markup with the various options applied.

```
<!DOCTYPE html>
<html>
  <head>
    <link rel="preconnect" href="https://fonts.googleapis.com">
    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">

    <style>
      :root {
        font-family: Inter;
        font-size: 8.5pt;
      }

/*
    * {
      text-rendering: geometricprecision !important;
    }
*/
    </style>
  </head>
  <body>
    <p style="font-size: 0.75rem;">Hello World</p>
  </body>
</html>
```

```
iex> ChromicPDF.start_link(); {:ok, pdf} = ChromicPDF.print_to_pdf({:file, "test.html"}, evaluate: %{expression: "new Promise(resolve => setTimeout(resolve, 2000))" }); File.write!("test.pdf", Base.decode64!(pdf))
```


### Results

| Desc | Image | PDF |
| ------ | ------ | ------ |
| nothing | ![image](https://github.com/bitcrowd/chromic_pdf/assets/96114/abcd6699-549d-4c48-b8f4-c08ff4e32dd0) | [test-current.pdf](https://github.com/bitcrowd/chromic_pdf/files/11846747/test-current.pdf) |
| `--font-render-hinting=medium` | ![image](https://github.com/bitcrowd/chromic_pdf/assets/96114/3b563c32-2aa1-463e-94cb-ede54d76c36b) | [test-font-render-hinting-medium.pdf](https://github.com/bitcrowd/chromic_pdf/files/11846753/test-font-render-hinting-medium.pdf) |
| `--font-render-hinting=none` | ![image](https://github.com/bitcrowd/chromic_pdf/assets/96114/e6888830-632b-4414-8496-d593da959e4f) | [test-font-render-hinting-none.pdf](https://github.com/bitcrowd/chromic_pdf/files/11846763/test-font-render-hinting-none.pdf) | 
| `text-rendering: geometricPrecision` | ![image](https://github.com/bitcrowd/chromic_pdf/assets/96114/55b2a1de-a9fb-44a8-b29b-62bd8bc39d9b) | [test-text-rendering-geometric-precision.pdf](https://github.com/bitcrowd/chromic_pdf/files/11846779/test-text-rendering-geometric-precision.pdf) |





