### PR TITLE
Add :console_api_calls global option.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+# locked to the versions we use in the lint CI job
+elixir 1.14.0
+erlang 25.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- Add `:console_api_calls` option to configure handling of `console.foo` calls in JS runtime (ignore, log, raise).
 - Document fixes for font rendering issues, and give `ChromicPDF.Template` a `text_rendering` option to allow applying `text-rendering: geometricPrecision;` on all elements.
 
 ## [1.11.0] - 2024-06-19

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -338,16 +338,25 @@ defmodule ChromicPDF do
 
   ## Further options
 
-  ### Debugging unhandled runtime exceptions
+  ### Debugging JavaScript errors & warnings
 
-  By default, runtime exceptions thrown in JavaScript execution contexts are logged. You may
-  choose to instead convert them into an Elixir exception by passing the following option:
+  By default, unhandled runtime exceptions thrown in JavaScript execution contexts are logged.
+  You may choose to instead convert them into an Elixir exception by passing the following option:
 
       defp chromic_pdf_opts do
+        # :ignore | :log (default) | :raise
         [unhandled_runtime_exceptions: :raise]
       end
 
   Alternatively, you can pass `:ignore` to silence the log statement.
+
+  Calls to `console.log` & friends are ignored by default, and can be configured to be logged
+  like this:
+
+      defp chromic_pdf_opts do
+        # :ignore (default) | :log | :raise
+        [console_api_calls: :log]
+      end
 
   ## On Accessibility / PDF/UA
 

--- a/lib/chromic_pdf/api/chrome_error.ex
+++ b/lib/chromic_pdf/api/chrome_error.ex
@@ -16,11 +16,15 @@ defmodule ChromicPDF.ChromeError do
     """
   end
 
-  defp title_for_error({:exception_thrown, _error}) do
+  defp title_for_error({:exception_thrown, _}) do
     "Unhandled exception in JS runtime"
   end
 
-  defp title_for_error({:evaluate, _error}) do
+  defp title_for_error({:console_api_called, _}) do
+    "Console API called in JS runtime"
+  end
+
+  defp title_for_error({:evaluate, _}) do
     "Exception in :evaluate expression"
   end
 
@@ -51,13 +55,19 @@ defmodule ChromicPDF.ChromeError do
     """
   end
 
-  defp hint_for_error({:exception_thrown, error}, _opts) do
-    %{"exception" => %{"description" => description}} = error
-
+  defp hint_for_error({:exception_thrown, description}, _opts) do
     """
     Exception:
 
     #{indent(description)}
+    """
+  end
+
+  defp hint_for_error({:console_api_called, {type, args}}, _opts) do
+    """
+    console.#{type} called:
+
+    #{indent(args)}
     """
   end
 

--- a/lib/chromic_pdf/pdf/protocol.ex
+++ b/lib/chromic_pdf/pdf/protocol.ex
@@ -165,6 +165,8 @@ defmodule ChromicPDF.Protocol do
         :ignore_certificate_errors => true,
         :ghostscript_pool => true,
         :on_demand => true,
+        :unhandled_runtime_exceptions => true,
+        :console_api_calls => true,
         :__protocol__ => true
       }
     }

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -211,6 +211,7 @@ defmodule ChromicPDF.Supervisor do
               | {:offline, boolean()}
               | {:disable_scripts, boolean()}
               | {:unhandled_runtime_exceptions, :ignore | :log | :raise}
+              | {:console_api_calls, :ignore | :log | :raise}
               | {:max_session_uses, non_neg_integer()}
               | {:session_pool, [session_pool_option()]}
               | {:ignore_certificate_errors, boolean()}


### PR DESCRIPTION
This patch adds the `:console_api_calls` global option, which works the same as the `:unhandled_runtime_exception` option in that it can be set to `:ignore`, `:log`, or `:raise`. By default, console API calls are ignored.