### PR TITLE
Add named session pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Add support for *named session pools*. These can be used to give persistent session options (`offline`, `disable_scripts`, ...) different values, for example to have one template that is not allowed to execute JavaScript and while others can use JavaScript.
+
 ### Changed
 
 - Deprecate `:max_session_uses` option in favor of `session_pool: [max_uses: ...]`.

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -182,7 +182,7 @@ defmodule ChromicPDF do
   ### Multiple session pools
 
   ChromicPDF supports running multiple named session pools to allow varying session configuration.
-  For example, this makes it possible to one pool that is not allowed to execute JavaScript while
+  For example, this makes it possible to have one pool that is not allowed to execute JavaScript while
   others can use JavaScript.
 
       defp chromic_pdf_opts do

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -129,22 +129,20 @@ defmodule ChromicPDF do
         [ignore_certificate_errors: true]
       end
 
-  ## Worker pools
+  ## Session pool
 
-  ChromicPDF spawns two worker pools, the session pool and the ghostscript pool. By default, it
-  will create as many sessions (browser tabs) as schedulers are online, and allow the same number
-  of concurrent Ghostscript processes to run.
+  ChromicPDF spawns a pool of targets (= tabs) inside the launched Chrome process. These are held
+  in memory to reduce initialization time in the PDF print jobs.
 
   ### Concurrency
 
   To increase or limit the number of concurrent workers, you can pass pool configuration to the
-  supervisor. Please note that these are non-queueing worker pools. If you intend to max them out,
+  supervisor. Please note that this is a non-queueing session pool. If you intend to max it out,
   you will need a job queue as well.
 
       defp chromic_pdf_opts do
         [
           session_pool: [size: 3]
-          ghostscript_pool: [size: 10]
         ]
       end
 
@@ -180,6 +178,28 @@ defmodule ChromicPDF do
           session_pool: [max_uses: 1000]
         ]
       end
+
+  ### Multiple session pools
+
+  ChromicPDF supports running multiple named session pools to allow varying session configuration.
+  For example, this makes it possible to one pool that is not allowed to execute JavaScript while
+  others can use JavaScript.
+
+      defp chromic_pdf_opts do
+        [
+          session_pool: %{
+            with_scripts: [],
+            without_scripts: [disabled_scripts: true]
+          }
+        ]
+      end
+
+  When you define multiple session pools, you need to assign the pool to use in each PDF job:
+
+      ChromicPDF.print_to_pdf(..., session_pool: :without_scripts)
+
+  Global options are used as defaults for each configured pool. See
+  `t:ChromicPDF.session_option/0` for a list of options for the session pools.
 
   ## Chrome zombies
 
@@ -310,6 +330,18 @@ defmodule ChromicPDF do
   > #### Experimental {: .warning}
   >
   > Please note that support for remote connections is considered experimental. Be aware that between restarts ChromicPDF may leave tabs behind and your external Chrome process may leak memory.
+
+  ## Ghostscript pool
+
+  In addition to the session pool, a pool of ghostscript "executors" is started, in order to limit
+  this resource as well. By default, ChromicPDF allows the same number of concurrent Ghostscript
+  processes to run as it spawns sessions in Chrome itself.
+
+      defp chromic_pdf_opts do
+        [
+          ghostscript_pool: [size: 10]
+        ]
+      end
 
   ## Telemetry support
 

--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -4,38 +4,55 @@ defmodule ChromicPDF.Browser do
   @moduledoc false
 
   use Supervisor
-  import ChromicPDF.Utils, only: [find_supervisor_child: 2]
-  alias ChromicPDF.Browser.{Channel, SessionPool}
+  import ChromicPDF.Utils, only: [find_supervisor_child!: 2, supervisor_children: 2]
+  alias ChromicPDF.Browser.{Channel, ExecutionError, SessionPool}
 
   # ------------- API ----------------
 
   @spec start_link(Keyword.t()) :: Supervisor.on_start()
-  def start_link(args) do
-    Supervisor.start_link(__MODULE__, args)
+  def start_link(config) do
+    Supervisor.start_link(__MODULE__, config)
   end
 
   @spec channel(pid()) :: pid()
-  def channel(supervisor), do: find_supervisor_child(supervisor, Channel)
-
-  @spec session_pool(pid()) :: pid()
-  def session_pool(supervisor), do: find_supervisor_child(supervisor, SessionPool)
+  def channel(supervisor), do: find_supervisor_child!(supervisor, Channel)
 
   @spec run_protocol(pid(), module(), keyword()) :: {:ok, any()} | {:error, term()}
   def run_protocol(supervisor, protocol, params) do
     supervisor
-    |> session_pool()
+    |> session_pool(params)
     |> SessionPool.run_protocol(protocol, params)
+  end
+
+  defp session_pool(supervisor, params) do
+    name = SessionPool.pool_name_from_params(params)
+
+    supervisor
+    |> supervisor_children(SessionPool)
+    |> Enum.find(fn {{SessionPool, id}, _pid} -> id == name end)
+    |> case do
+      {_, pid} ->
+        pid
+
+      nil ->
+        raise ExecutionError, """
+        Could not find session pool named #{inspect(name)}!"
+        """
+    end
   end
 
   # ------------ Callbacks -----------
 
   @impl Supervisor
-  def init(args) do
-    children = [
-      {Channel, args},
-      {SessionPool, args}
-    ]
+  def init(config) do
+    children = [{Channel, config} | session_pools(config)]
 
     Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  defp session_pools(config) do
+    for opts <- SessionPool.pools_from_config(config) do
+      {SessionPool, opts}
+    end
   end
 end

--- a/lib/chromic_pdf/pdf/browser/channel.ex
+++ b/lib/chromic_pdf/pdf/browser/channel.ex
@@ -12,8 +12,8 @@ defmodule ChromicPDF.Browser.Channel do
   # ------------- API ----------------
 
   @spec start_link(Keyword.t()) :: GenServer.on_start()
-  def start_link(args) do
-    GenServer.start_link(__MODULE__, args)
+  def start_link(config) do
+    GenServer.start_link(__MODULE__, config)
   end
 
   @spec run_protocol(pid(), Protocol.t(), timeout()) :: {:ok, any()} | {:error, term()}
@@ -45,8 +45,8 @@ defmodule ChromicPDF.Browser.Channel do
   # ----------- Callbacks ------------
 
   @impl GenServer
-  def init(args) do
-    {:ok, conn_pid} = Connection.start_link(args)
+  def init(config) do
+    {:ok, conn_pid} = Connection.start_link(config)
 
     {:ok,
      %{
@@ -109,7 +109,7 @@ defmodule ChromicPDF.Browser.Channel do
          Docker runtime provides only 64 MB to containers by default.
 
          Pass --disable-dev-shm-usage as a Chrome flag to use /tmp for this purpose instead
-         (via the chrome_args option), or increase the amount of shared memory available to
+         (via the chrome_config option), or increase the amount of shared memory available to
          the container (see --shm-size for Docker).
       """)
     end

--- a/test/integration/fixtures/test_exception.html
+++ b/test/integration/fixtures/test_exception.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <script>doesnotexist();</script>
+  </body>
+</html>

--- a/test/integration/pdf_generation_test.exs
+++ b/test/integration/pdf_generation_test.exs
@@ -276,14 +276,6 @@ defmodule ChromicPDF.PDFGenerationTest do
     end
   end
 
-  @html_with_runtime_exception """
-  <html>
-    <body id="print-ready">
-      <script>doesnotexist();</script>
-    </body>
-  </html>
-  """
-
   describe "unhandled runtime exceptions" do
     setup do
       start_supervised!(ChromicPDF)
@@ -292,7 +284,7 @@ defmodule ChromicPDF.PDFGenerationTest do
 
     test "are logged by default" do
       assert capture_log(fn ->
-               assert print_to_pdf({:html, @html_with_runtime_exception}) == :ok
+               assert print_to_pdf({:html, test_exception_html()}) == :ok
              end) =~ ~r/Unhandled exception in JS runtime/
     end
   end
@@ -305,7 +297,7 @@ defmodule ChromicPDF.PDFGenerationTest do
 
     test "are ignored" do
       assert capture_log(fn ->
-               assert print_to_pdf({:html, @html_with_runtime_exception}) == :ok
+               assert print_to_pdf({:html, test_exception_html()}) == :ok
              end) == ""
     end
   end
@@ -318,7 +310,7 @@ defmodule ChromicPDF.PDFGenerationTest do
 
     test "raise nicely formatted errors" do
       assert_raise ChromicPDF.ChromeError, ~r/Unhandled exception in JS runtime/, fn ->
-        print_to_pdf({:html, @html_with_runtime_exception})
+        print_to_pdf({:html, test_exception_html()})
       end
     end
   end

--- a/test/integration/support/test_api.ex
+++ b/test/integration/support/test_api.ex
@@ -8,6 +8,7 @@ defmodule ChromicPDF.TestAPI do
 
   @test_html Path.expand("../../fixtures/test.html", __ENV__.file)
   @test_dynamic_html Path.expand("../../fixtures/test_dynamic.html", __ENV__.file)
+  @test_exception_html Path.expand("../../fixtures/test_exception.html", __ENV__.file)
   @test_image Path.expand("../../fixtures/image_with_text.svg", __ENV__.file)
 
   @output Path.expand("../../test.pdf", __ENV__.file)
@@ -17,6 +18,9 @@ defmodule ChromicPDF.TestAPI do
 
   def test_dynamic_html_path, do: @test_dynamic_html
   def test_dynamic_html, do: File.read!(test_dynamic_html_path())
+
+  defp test_exception_html_path, do: @test_exception_html
+  def test_exception_html, do: File.read!(test_exception_html_path())
 
   def test_image_path, do: @test_image
 


### PR DESCRIPTION
This adds support for multiple named session pools.

I figured that people in the past repeatedly wanted to have different values for our "global" options (e.g. `disable_scripts`) per print job, or rather likely per template. As this goes against my original idea of keeping "initialization work" strictly to the initialization (`SpawnSession`) and keep the amount of work per print job to a minimum, I'm inclined to point people to the existing possibility of launching multiple ChromicPDF instances with different configs (think: print queues). However, launching a separate ChromicPDF supervisor means launching additional OS processes of chromium, which seems wasteful. At this point I realized that we're lacking a middle layer in the session pool, i.e. differently configured sessions. This PR fixes that by introducing **named session pools** that can have pool-specific configs.

## API

```elixir
iex> ChromicPDF.start_link(session_pool: %{noscript: [disable_scripts: true], withscripts: []})
iex> ChromicPDF.print_to_pdf({:html, "test"}, session_pool: :noscript)
```

## Docs

![image](https://github.com/bitcrowd/chromic_pdf/assets/96114/31a11723-90a4-4920-8b29-7a0731645867)

![image](https://github.com/bitcrowd/chromic_pdf/assets/96114/f4990ecb-e20e-4573-885e-e7114c57d8e0)