### PR TITLE
Refactor SessionPool, store pool config in agent

### DIFF
--- a/lib/chromic_pdf/api.ex
+++ b/lib/chromic_pdf/api.ex
@@ -69,7 +69,7 @@ defmodule ChromicPDF.API do
 
     with_telemetry(protocol, opts, fn ->
       services.browser
-      |> Browser.run_protocol(Map.fetch!(@export_protocols, protocol), opts)
+      |> Browser.new_protocol(Map.fetch!(@export_protocols, protocol), opts)
       |> ExportOptions.feed_chrome_data_into_output(opts)
     end)
   end

--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -5,7 +5,8 @@ defmodule ChromicPDF.Browser do
 
   use Supervisor
   import ChromicPDF.Utils, only: [find_supervisor_child!: 2, supervisor_children: 2]
-  alias ChromicPDF.Browser.{Channel, ExecutionError, SessionPool}
+  alias ChromicPDF.Browser.{Channel, ExecutionError, SessionPool, SessionPoolConfig}
+  alias ChromicPDF.{CloseTarget, Protocol, SpawnSession}
 
   # ------------- API ----------------
 
@@ -14,31 +15,21 @@ defmodule ChromicPDF.Browser do
     Supervisor.start_link(__MODULE__, config)
   end
 
-  @spec channel(pid()) :: pid()
-  def channel(supervisor), do: find_supervisor_child!(supervisor, Channel)
+  @spec new_protocol(pid(), module(), keyword()) :: {:ok, any()} | {:error, term()}
+  def new_protocol(supervisor, protocol_mod, params) do
+    {session_pool, pool_config} = find_session_pool_with_config(supervisor, params)
 
-  @spec run_protocol(pid(), module(), keyword()) :: {:ok, any()} | {:error, term()}
-  def run_protocol(supervisor, protocol, params) do
-    supervisor
-    |> session_pool(params)
-    |> SessionPool.run_protocol(protocol, params)
-  end
+    checkout_opts = [
+      skip_session_use_count: Keyword.get(params, :skip_session_use_count, false),
+      timeout: 5000
+    ]
 
-  defp session_pool(supervisor, params) do
-    name = SessionPool.pool_name_from_params(params)
+    SessionPool.checkout!(session_pool, checkout_opts, fn %{session_id: session_id} ->
+      protocol = protocol_mod.new(session_id, Keyword.merge(pool_config, params))
+      timeout = Keyword.fetch!(pool_config, :timeout)
 
-    supervisor
-    |> supervisor_children(SessionPool)
-    |> Enum.find(fn {{SessionPool, id}, _pid} -> id == name end)
-    |> case do
-      {_, pid} ->
-        pid
-
-      nil ->
-        raise ExecutionError, """
-        Could not find session pool named #{inspect(name)}!"
-        """
-    end
+      run_protocol(supervisor, protocol, timeout)
+    end)
   end
 
   # ------------ Callbacks -----------
@@ -51,8 +42,71 @@ defmodule ChromicPDF.Browser do
   end
 
   defp session_pools(config) do
-    for opts <- SessionPool.pools_from_config(config) do
-      {SessionPool, opts}
-    end
+    browser = self()
+
+    pools = SessionPoolConfig.pools_from_config(config)
+    agent = {Agent, fn -> Map.new(pools) end}
+
+    pools =
+      for {id, pool_config} <- pools do
+        {SessionPool,
+         {id,
+          pool_size: Keyword.fetch!(pool_config, :size),
+          max_uses: Keyword.fetch!(pool_config, :max_uses),
+          init_worker: fn ->
+            protocol = SpawnSession.new(pool_config)
+            timeout = Keyword.fetch!(pool_config, :init_timeout)
+
+            {:ok, %{"sessionId" => sid, "targetId" => tid}} =
+              run_protocol(browser, protocol, timeout)
+
+            %{session_id: sid, target_id: tid}
+          end,
+          terminate_worker: fn %{target_id: target_id} ->
+            protocol = CloseTarget.new(targetId: target_id)
+            timeout = Keyword.fetch!(pool_config, :close_timeout)
+
+            {:ok, _} = run_protocol(browser, protocol, timeout)
+          end}}
+      end
+
+    [agent | pools]
+  end
+
+  # ---------- Dealing with supervisor children -----------
+
+  defp run_protocol(supervisor, %Protocol{} = protocol, timeout) do
+    supervisor
+    |> find_channel()
+    |> Channel.run_protocol(protocol, timeout)
+  end
+
+  defp find_agent(supervisor), do: find_supervisor_child!(supervisor, Agent)
+  defp find_channel(supervisor), do: find_supervisor_child!(supervisor, Channel)
+
+  defp find_session_pool_with_config(supervisor, params) do
+    name = SessionPoolConfig.pool_name_from_params(params)
+
+    pool =
+      supervisor
+      |> supervisor_children(SessionPool)
+      |> Enum.find(fn {{SessionPool, id}, _pid} -> id == name end)
+      |> case do
+        {_, pid} ->
+          pid
+
+        nil ->
+          raise ExecutionError, """
+          Could not find session pool named #{inspect(name)}!"
+          """
+      end
+
+    config =
+      supervisor
+      |> find_agent()
+      |> Agent.get(& &1)
+      |> Map.fetch!(name)
+
+    {pool, config}
   end
 end

--- a/lib/chromic_pdf/pdf/browser/session_pool.ex
+++ b/lib/chromic_pdf/pdf/browser/session_pool.ex
@@ -6,184 +6,103 @@ defmodule ChromicPDF.Browser.SessionPool do
   @behaviour NimblePool
 
   require Logger
-  import ChromicPDF.Utils, only: [default_pool_size: 0]
-  alias ChromicPDF.Browser
-  alias ChromicPDF.Browser.{Channel, ExecutionError}
-  alias ChromicPDF.{CloseTarget, SpawnSession}
+  alias ChromicPDF.Browser.ExecutionError
 
-  @default_init_timeout 5000
-  @default_timeout 5000
-  @checkout_timeout 5000
-  @close_timeout 1000
-  @default_max_uses 1000
-
-  @default_pool_name :default
+  @type session :: any()
 
   @type pool_state :: %{
-          browser: pid(),
-          config: keyword()
+          init_worker: (() -> session()),
+          terminate_worker: (session() -> any()),
+          max_uses: non_neg_integer()
         }
 
   @type worker_state :: %{
-          session_id: binary(),
-          target_id: binary(),
+          session: session(),
           uses: non_neg_integer()
         }
 
-  # ------------- API ----------------
-
-  # Normalizes global :session_pool option (keywords for default pool or map of named pools) into
-  # a list of supervisor ids and pool options as combined from globals and named pool overrides.
-  @spec pools_from_config(keyword()) :: [{__MODULE__, keyword()}]
-  def pools_from_config(config) do
-    named_pools =
-      case Keyword.get(config, :session_pool, []) do
-        opts when is_list(opts) -> %{@default_pool_name => opts}
-        named_pools when is_map(named_pools) -> named_pools
-      end
-
-    for {name, opts} <- named_pools do
-      {name, Keyword.merge(config, opts)}
-    end
-  end
-
-  @spec pool_name_from_params(keyword()) :: atom()
-  def pool_name_from_params(pdf_params) do
-    Keyword.get(pdf_params, :session_pool, @default_pool_name)
-  end
+  @type checkout_option :: {:skip_session_use_count, boolean()} | {:timeout, non_neg_integer()}
+  @type checkout_result :: any()
 
   @spec child_spec({atom(), keyword()}) :: Supervisor.child_spec()
-  def child_spec({id, config}) do
+  def child_spec({id, opts}) do
     %{
       id: {__MODULE__, id},
-      start: {__MODULE__, :start_link, [self(), config]}
+      start: {__MODULE__, :start_link, [opts]}
     }
   end
 
-  @spec start_link(pid(), Keyword.t()) :: GenServer.on_start()
-  def start_link(browser_pid, config) do
-    NimblePool.start_link(
-      worker: {__MODULE__, {browser_pid, config}},
-      pool_size: Keyword.get(config, :size, default_pool_size())
-    )
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts) do
+    {pool_size, opts} = Keyword.pop!(opts, :pool_size)
+
+    NimblePool.start_link(worker: {__MODULE__, Map.new(opts)}, pool_size: pool_size)
   end
 
-  @spec run_protocol(pid(), module(), keyword()) :: {:ok, any()} | {:error, term()}
-  def run_protocol(pid, protocol_mod, params) do
-    NimblePool.checkout!(
-      pid,
-      command(params),
-      fn _, {pool_state, session} ->
-        do_run_protocol(protocol_mod, params, pool_state, session)
-      end,
-      @checkout_timeout
-    )
-  catch
-    :exit, {:timeout, _} ->
-      raise(ExecutionError, """
-      Caught EXIT signal from NimblePool.checkout!/4
+  @spec checkout!(pid, [checkout_option], (session -> checkout_result)) :: checkout_result
+  def checkout!(pid, opts, fun) do
+    command =
+      if Keyword.fetch!(opts, :skip_session_use_count) do
+        :checkout
+      else
+        :checkout_and_count
+      end
 
-            ** (EXIT) time out
+    timeout = Keyword.fetch!(opts, :timeout)
 
-      This means that your operation was unable to acquire a worker from the pool
-      within #{@checkout_timeout}ms, as all workers are currently occupied.
+    try do
+      NimblePool.checkout!(
+        pid,
+        command,
+        fn _, {_pool_state, session} -> {fun.(session), :ok} end,
+        timeout
+      )
+    catch
+      :exit, {:timeout, _} ->
+        raise(ExecutionError, """
+        Caught EXIT signal from NimblePool.checkout!/4
 
-      Two scenarios where this may happen:
+              ** (EXIT) time out
 
-      1) You suffer from this error at boot time or in your CI. For instance,
-         you're running PDF printing tests in CI and occasionally the first of these test
-         fails. This may be caused by Chrome being delayed by initialization tasks when
-         it is first launched.
+        This means that your operation was unable to acquire a worker from the pool
+        within #{timeout}ms, as all workers are currently occupied.
 
-         See ChromicPDF.warm_up/1 for a possible mitigation.
+        Two scenarios where this may happen:
 
-      2) You're experiencing this error randomly under load. This would indicate that
-         the number of concurrent print jobs exceeds the total number of workers in
-         the pool, so that all workers are occupied.
+        1) You suffer from this error at boot time or in your CI. For instance,
+           you're running PDF printing tests in CI and occasionally the first of these test
+           fails. This may be caused by Chrome being delayed by initialization tasks when
+           it is first launched.
 
-         To fix this, you need to increase your resources, e.g. by increasing the number
-         of workers with the `session_pool: [size: ...]` option.
+           See ChromicPDF.warm_up/1 for a possible mitigation.
 
-         However, please be aware that while ChromicPDF (by virtue of the underlying
-         NimblePool worker pool) does perform simple queueing of worker checkouts,
-         it is not suitable as a proper job queue. If you expect to peaks in your load
-         leading to a high level of concurrent use of your PDF printing component,
-         a job queue like Oban will provide a better experience.
+        2) You're experiencing this error randomly under load. This would indicate that
+           the number of concurrent print jobs exceeds the total number of workers in
+           the pool, so that all workers are occupied.
 
-      Please also consult the worker pool section in the documentation.
-      """)
-  end
+           To fix this, you need to increase your resources, e.g. by increasing the number
+           of workers with the `session_pool: [size: ...]` option.
 
-  defp command(params) do
-    if params[:skip_session_use_count] do
-      :checkout
-    else
-      :checkout_and_count
+           However, please be aware that while ChromicPDF (by virtue of the underlying
+           NimblePool worker pool) does perform simple queueing of worker checkouts,
+           it is not suitable as a proper job queue. If you expect peaks in your load
+           leading to a high level of concurrent use of your PDF printing component,
+           a job queue like Oban will provide a better experience.
+
+        Please also consult the worker pool section in the documentation.
+        """)
     end
-  end
-
-  defp do_run_protocol(protocol_mod, params, %{browser: browser, config: config}, %{
-         session_id: session_id
-       }) do
-    protocol = protocol_mod.new(session_id, Keyword.merge(config, params))
-
-    result =
-      browser
-      |> Browser.channel()
-      |> Channel.run_protocol(protocol, timeout(config))
-
-    {result, :ok}
   end
 
   # ------------ Callbacks -----------
-
-  @impl NimblePool
-  def init_pool({browser, config}) do
-    config =
-      config
-      |> Keyword.put_new(:offline, false)
-      |> Keyword.put_new(:ignore_certificate_errors, false)
-      |> Keyword.put_new(:unhandled_runtime_exceptions, :log)
-
-    {:ok, %{browser: browser, config: config}}
-  end
-
-  defp timeout(config) do
-    Keyword.get(config, :timeout, @default_timeout)
-  end
-
-  defp init_timeout(config) do
-    Keyword.get(config, :init_timeout, @default_init_timeout)
-  end
-
-  defp max_uses(config) do
-    Keyword.get(config, :max_uses) || max_session_uses(config) || @default_max_uses
-  end
-
-  defp max_session_uses(config) do
-    if max_session_uses = Keyword.get(config, :max_session_uses) do
-      IO.warn("""
-      [ChromicPDF] :max_session_uses option is deprecated, change your config to:
-
-          [session_pool: [max_uses: #{max_session_uses}]]
-      """)
-
-      max_session_uses
-    end
-  end
 
   @impl NimblePool
   def init_worker(pool_state) do
     {:async, fn -> do_init_worker(pool_state) end, pool_state}
   end
 
-  defp do_init_worker(%{browser: browser, config: config}) do
-    {:ok, %{"sessionId" => sid, "targetId" => tid}} =
-      browser
-      |> Browser.channel()
-      |> Channel.run_protocol(SpawnSession.new(config), init_timeout(config))
-
-    %{session: %{session_id: sid, target_id: tid}, uses: 0}
+  defp do_init_worker(%{init_worker: init_worker}) do
+    %{session: init_worker.(), uses: 0}
   end
 
   @impl NimblePool
@@ -201,7 +120,7 @@ defmodule ChromicPDF.Browser.SessionPool do
 
   @impl NimblePool
   def handle_checkin(:ok, _from, worker_state, pool_state) do
-    if worker_state.uses >= max_uses(pool_state.config) do
+    if worker_state.uses >= pool_state.max_uses do
       {:remove, :max_uses_reached, pool_state}
     else
       {:ok, worker_state, pool_state}
@@ -225,12 +144,7 @@ defmodule ChromicPDF.Browser.SessionPool do
     end
 
     Task.async(fn ->
-      protocol = CloseTarget.new(targetId: worker_state.session.target_id)
-
-      {:ok, true} =
-        pool_state.browser
-        |> Browser.channel()
-        |> Channel.run_protocol(protocol, @close_timeout)
+      pool_state.terminate_worker.(worker_state.session)
     end)
 
     {:ok, pool_state}

--- a/lib/chromic_pdf/pdf/browser/session_pool_config.ex
+++ b/lib/chromic_pdf/pdf/browser/session_pool_config.ex
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule ChromicPDF.Browser.SessionPoolConfig do
+  @moduledoc false
+
+  import ChromicPDF.Utils, only: [default_pool_size: 0]
+
+  @default_timeout 5000
+  @default_init_timeout 5000
+  @default_close_timeout 1000
+  @default_max_uses 1000
+
+  @default_pool_name :default
+
+  # Normalizes global :session_pool option (keywords for default pool or map of named pools) into
+  # a list of supervisor ids and pool options as combined from globals and named pool overrides.
+  @spec pools_from_config(keyword()) :: [{__MODULE__, keyword()}]
+  def pools_from_config(config) do
+    config
+    |> extract_named_pools()
+    |> merge_globals_and_put_defaults(config)
+  end
+
+  defp extract_named_pools(config) do
+    case Keyword.get(config, :session_pool, []) do
+      opts when is_list(opts) -> %{@default_pool_name => opts}
+      named_pools when is_map(named_pools) -> named_pools
+    end
+  end
+
+  defp merge_globals_and_put_defaults(named_pools, config) do
+    for {name, opts} <- named_pools do
+      merged =
+        config
+        |> Keyword.merge(opts)
+        |> Keyword.put_new(:size, default_pool_size())
+        |> Keyword.put_new(:timeout, @default_timeout)
+        |> Keyword.put_new(:init_timeout, @default_init_timeout)
+        |> Keyword.put_new(:close_timeout, @default_close_timeout)
+        |> put_default_max_uses()
+        |> Keyword.put_new(:offline, false)
+        |> Keyword.put_new(:ignore_certificate_errors, false)
+        |> Keyword.put_new(:unhandled_runtime_exceptions, :log)
+
+      {name, merged}
+    end
+  end
+
+  defp put_default_max_uses(config) do
+    cond do
+      Keyword.has_key?(config, :max_uses) ->
+        config
+
+      Keyword.has_key?(config, :max_session_uses) ->
+        {max_session_uses, config} = Keyword.pop(config, :max_session_uses)
+
+        IO.warn("""
+        [ChromicPDF] :max_session_uses option is deprecated, change your config to:
+
+            [session_pool: [max_uses: #{max_session_uses}]]
+        """)
+
+        Keyword.put(config, :max_uses, max_session_uses)
+
+      true ->
+        Keyword.put(config, :max_uses, @default_max_uses)
+    end
+  end
+
+  # Returns the targeted session pool from a map of PDF job params or the default pool name.
+  @spec pool_name_from_params(keyword()) :: atom()
+  def pool_name_from_params(pdf_params) do
+    Keyword.get(pdf_params, :session_pool, @default_pool_name)
+  end
+end

--- a/test/integration/support/get_targets.ex
+++ b/test/integration/support/get_targets.ex
@@ -15,7 +15,7 @@ defmodule ChromicPDF.GetTargets do
   def run do
     {:ok, target_infos} =
       ChromicPDF.Supervisor.with_services(ChromicPDF, fn services ->
-        ChromicPDF.Browser.run_protocol(services.browser, __MODULE__, skip_session_use_count: true)
+        ChromicPDF.Browser.new_protocol(services.browser, __MODULE__, skip_session_use_count: true)
       end)
 
     for %{"targetId" => target_id, "url" => url} <- target_infos,


### PR DESCRIPTION
- Refactors SessionPool to be only concerned with session counting
- Worker init & teardown is parameterized by passing in functions from browser now. These functions capture the config as needed.
- New Agent in Browser stores the pool configs by name for later lookup.