### PR TITLE
[#276] Make checkout timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+- Configurable pool checkout timeout via new global option `:checkout_timeout`.
+
 ## [1.13.0] - 2024-08-17
 
 ### Added

--- a/lib/chromic_pdf/pdf/browser.ex
+++ b/lib/chromic_pdf/pdf/browser.ex
@@ -21,7 +21,7 @@ defmodule ChromicPDF.Browser do
 
     checkout_opts = [
       skip_session_use_count: Keyword.get(params, :skip_session_use_count, false),
-      timeout: 5000
+      timeout: Keyword.fetch!(pool_config, :checkout_timeout)
     ]
 
     SessionPool.checkout!(session_pool, checkout_opts, fn %{session_id: session_id} ->

--- a/lib/chromic_pdf/pdf/browser/session_pool.ex
+++ b/lib/chromic_pdf/pdf/browser/session_pool.ex
@@ -83,13 +83,7 @@ defmodule ChromicPDF.Browser.SessionPool do
            To fix this, you need to increase your resources, e.g. by increasing the number
            of workers with the `session_pool: [size: ...]` option.
 
-           However, please be aware that while ChromicPDF (by virtue of the underlying
-           NimblePool worker pool) does perform simple queueing of worker checkouts,
-           it is not suitable as a proper job queue. If you expect peaks in your load
-           leading to a high level of concurrent use of your PDF printing component,
-           a job queue like Oban will provide a better experience.
-
-        Please also consult the worker pool section in the documentation.
+        Please also consult the session pool concurrency section in the documentation.
         """)
     end
   end

--- a/lib/chromic_pdf/pdf/browser/session_pool_config.ex
+++ b/lib/chromic_pdf/pdf/browser/session_pool_config.ex
@@ -8,6 +8,7 @@ defmodule ChromicPDF.Browser.SessionPoolConfig do
   @default_timeout 5000
   @default_init_timeout 5000
   @default_close_timeout 1000
+  @default_checkout_timeout 5000
   @default_max_uses 1000
 
   @default_pool_name :default
@@ -37,6 +38,7 @@ defmodule ChromicPDF.Browser.SessionPoolConfig do
         |> Keyword.put_new(:timeout, @default_timeout)
         |> Keyword.put_new(:init_timeout, @default_init_timeout)
         |> Keyword.put_new(:close_timeout, @default_close_timeout)
+        |> Keyword.put_new(:checkout_timeout, @default_checkout_timeout)
         |> put_default_max_uses()
         |> Keyword.put_new(:offline, false)
         |> Keyword.put_new(:ignore_certificate_errors, false)

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -208,6 +208,7 @@ defmodule ChromicPDF.Supervisor do
               | {:size, non_neg_integer()}
               | {:max_uses, non_neg_integer()}
               | {:init_timeout, timeout()}
+              | {:checkout_timeout, timeout()}
               | {:timeout, timeout()}
 
       @type named_session_pools :: %{atom() => [session_pool_option()]}

--- a/test/integration/session_pool_test.exs
+++ b/test/integration/session_pool_test.exs
@@ -115,16 +115,15 @@ defmodule ChromicPDF.SessionPoolTest do
     end
   end
 
-  describe "failed worker checkout" do
+  describe "checkout timeout" do
     setup do
-      # Setting the job timeout to 10s to be sure we run into the checkout error.
-      start_supervised!({ChromicPDF, session_pool: [size: 1, timeout: 10_000]})
+      start_supervised!({ChromicPDF, session_pool: [size: 1, checkout_timeout: 500]})
 
       :ok
     end
 
     test "generates a nice error message" do
-      task = Task.async(fn -> print_to_pdf_delayed(7_000) end)
+      task = Task.async(fn -> print_to_pdf_delayed(1_000) end)
 
       # Wait for a little bit to make sure the task acquires the worker.
       :timer.sleep(300)


### PR DESCRIPTION
This patch adds a global `:checkout_timeout` option to configure the allowed wait-time of an operation in the session pool's queue.

This also deliberately drops the section on `:init_timeout` from the docs as I don't see why anyone would mess with that. Same goes for `:close_timeout` (configurable, but not advertised in the docs).

Fixes #276 

cc @axelclark 