### PR TITLE
Add Template.options/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Added
+
+- Add `Template.options/1` that returns the options for page dimensions, header, and footer, but does not require the content.
+
+### Changed
+
+- Strip styles generated in `Template.styles/1`.
+
 ## [1.14.0] - 2024-09-27
 
 ### Added


### PR DESCRIPTION
This patch adds `ChromicPDF.Template.options/1` to fetch the options for the `print_to_pdf/2` call without passing in the content.

Besides, styles generate by `Template.styles/1` are now squished.