### PR TITLE
Add another potential & likely default_executable name

### DIFF
--- a/lib/chromic_pdf/pdf/chrome_runner.ex
+++ b/lib/chromic_pdf/pdf/chrome_runner.ex
@@ -44,6 +44,7 @@ defmodule ChromicPDF.ChromeRunner do
   @default_executables [
     "chromium-browser",
     "chromium",
+    "chrome",
     "google-chrome",
     "/usr/bin/chromium-browser",
     "/usr/bin/chromium",


### PR DESCRIPTION
It seems the default .exe name on my windows server is 'chrome.exe', and as I assume that's probably fairly common so i've added it to the default list.