### PR TITLE
[#290] Fix missing footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+### Fixed
+
+- Recover missing custom footer templates by making sure we do not add any `@page` CSS rule to the header or footer templates in `ChromicPDF.Template.source_and_options/1`. (#290)
+- Drop the default `zoom: 0.75` rule from header and footer templates for Chrome >= v120. They removed the default scale-up by 4/3, see [chromium bug #1509917](https://bugs.chromium.org/p/chromium/issues/detail?id=1509917#c3).
+
+Note that for **remote chrome** users this means they will have to explicitly specify the chrome version in the application config.
+
+```elixir
+config :chromic_pdf, chrome_version: "Google Chrome 120.0.6099.71"
+```
+
 ### Added
 
 - Add `ChromicPDF.Plug` to forward Chrome requests on an internal endpoint to a template.
@@ -7,12 +18,13 @@
 
 ### Changed
 
-- Strip styles generated in `Template.styles/1`.
+- Split `Chromic.Template.styles/1` into `page_styles/1` and `header_footer_styles/1`, and trim the stylesheets.
 - Cookies set via `:set_cookie` are now `httpOnly: true` by default.
 
 ### Removed
 
 - Dropped the outdated Phoenix example in `examples/`.
+- Deprecated `ChromicPDF.styles/1`.
 
 ## [1.14.0] - 2023-09-27
 

--- a/lib/chromic_pdf/utils.ex
+++ b/lib/chromic_pdf/utils.ex
@@ -119,4 +119,32 @@ defmodule ChromicPDF.Utils do
     alias Phoenix.HTML.Safe
     def rendered_to_iodata(value), do: Safe.to_iodata(value)
   end
+
+  @spec with_app_config_cache(atom, function) :: any
+  def with_app_config_cache(key, function) do
+    case Application.get_env(:chromic_pdf, key) do
+      nil ->
+        result = function.()
+        Application.put_env(:chromic_pdf, key, result)
+        result
+
+      value ->
+        value
+    end
+  end
+
+  @spec semver_compare(binary, list) :: :lt | :eq | :gt
+  def semver_compare(x, y) do
+    x
+    |> String.trim()
+    |> String.split(".")
+    |> Enum.map(&String.to_integer/1)
+    |> Enum.zip(y)
+    |> do_semver_compare()
+  end
+
+  defp do_semver_compare([]), do: :eq
+  defp do_semver_compare([{x, y} | _rest]) when x < y, do: :lt
+  defp do_semver_compare([{x, y} | _rest]) when x > y, do: :gt
+  defp do_semver_compare([{x, y} | rest]) when x == y, do: do_semver_compare(rest)
 end

--- a/test/integration/screenshot_test.exs
+++ b/test/integration/screenshot_test.exs
@@ -51,9 +51,7 @@ defmodule ChromicPDF.ScreenshotTest do
 
     @tag :identify
     test ":full_page resizes the the device dimensions to fit the content" do
-      [major | _] = version()
-
-      if major >= 91 do
+      if semver_compare(version(), [91]) in [:eq, :gt] do
         {_, _, height} = capture_screenshot_and_identify(source: {:url, "file://#{@large_html}"})
         assert height < 4000
 

--- a/test/unit/chromic_pdf/utils_test.exs
+++ b/test/unit/chromic_pdf/utils_test.exs
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule ChromicPDF.UtilsTest do
+  use ExUnit.Case, async: true
+  import ChromicPDF.Utils
+
+  describe "semver_compare/2" do
+    test "compares a semver string with a hardcoded semver list" do
+      assert semver_compare("1.2.3", [1, 2, 3]) == :eq
+      assert semver_compare("1.2.3", [1, 2]) == :eq
+      assert semver_compare("1.1.3", [1, 2]) == :lt
+      assert semver_compare("1.3.0", [1, 2]) == :gt
+    end
+  end
+end


### PR DESCRIPTION
Fixes [[#290]](https://github.com/bitcrowd/chromic_pdf/issues/290)

Since Chrome 117 custom footers would not be displayed anymore when configured via `ChromicPDF.Template`. Reason for this was that our stylesheet was prepended to both the content markup as well as the header and footer templates. The `@page` rule contains the page margins which used to be ignored in the header and footer sections, but are not applied and lead to the footer being pushes out of its content box. Fixed by splitting `ChromicPDF.Template.styles/1` into `page_styles/1` and `header_footer_styles/1` and removing the `@page` directive from the header and footer styles.

Besides, this patch removes the `zoom` directive from the header and footer templates for Chrome >= v120, as they have removed the default 4/3 scale-up.