### PR TITLE
Only retry failed tests if the tests ran and failed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,4 +33,5 @@ jobs:
       - run: mix deps.get
       - run: mix compile
       - run: mix chromic_pdf.warm_up
-      - run: mix test || mix test --failed || mix test --failed
+      # only retry failed tests if the tests ran and actually failed (exit status 2), and don't retry if e.g. they didn't compile
+      - run: mix test || if [[ $? = 2 ]]; then mix test --failed || if [[ $? = 2 ]]; then mix test --failed; else false; fi; else false; fi


### PR DESCRIPTION
See https://github.com/elixir-lang/elixir/issues/11484

Running `mix test --failed` will report passing tests if on the previous run no tests failed. No tests failed on the previous run if the test code didn't compile at all.

The problem can be reproduced by:
- Adding any invalid gibberish to any test file
- Running `mix test || mix test --failed`
- Running `$?` - it will report last exit code of 0, even though you can see compilation errors in the output from the first test run.