### PR TITLE
Allow phoenix_html 4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule ChromicPdf.MixProject do
       {:nimble_pool, "~> 0.2 or ~> 1.0"},
       {:plug, "~> 1.11", optional: true},
       {:plug_crypto, "~> 1.2 or ~> 2.0", optional: true},
-      {:phoenix_html, "~> 2.14 or ~> 3.3", optional: true},
+      {:phoenix_html, "~> 2.14 or ~> 3.3 or ~> 4.0", optional: true},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:websockex, ">= 0.4.3", optional: true},
       {:dialyxir, "~> 1.2", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Chromic does not seem to rely on any functions removed in v4.0.0 : https://hexdocs.pm/phoenix_html/changelog.html