### PR TITLE
fix: correct hint about how to set chrome args

### DIFF
--- a/lib/chromic_pdf/pdf/browser/channel.ex
+++ b/lib/chromic_pdf/pdf/browser/channel.ex
@@ -109,7 +109,7 @@ defmodule ChromicPDF.Browser.Channel do
          Docker runtime provides only 64 MB to containers by default.
 
          Pass --disable-dev-shm-usage as a Chrome flag to use /tmp for this purpose instead
-         (via the chrome_config option), or increase the amount of shared memory available to
+         (via the chrome_args option), or increase the amount of shared memory available to
          the container (see --shm-size for Docker).
       """)
     end


### PR DESCRIPTION
Took me a while to figure out what this comment was actually referring to, so I hope this helps out somebody else 🙂 