### PR TITLE
Add additional default executables from Heroku buildpack

### DIFF
--- a/lib/chromic_pdf/pdf/chrome_runner.ex
+++ b/lib/chromic_pdf/pdf/chrome_runner.ex
@@ -70,7 +70,9 @@ defmodule ChromicPDF.ChromeRunner do
     "/usr/bin/chromium",
     "/usr/bin/google-chrome",
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium"
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "chrome",
+    "chromedriver"
   ]
 
   defp executable(opts \\ []) do


### PR DESCRIPTION
Add two filenames from the new Heroku Chrome buildpack https://blog.heroku.com/improved-browser-testing-on-heroku-with-chrome

The previous buildpacks I tried using Gigalixir didn't work:
https://github.com/heroku/heroku-buildpack-google-chrome
https://github.com/hermantolim/gigalixir-buildpack-google-chrome

However, the new "improved-browser-testing-on-heroku-with-chrome" installs as "chrome" and "chromedriver"

I tried just using `chrome_executable: chrome` to avoid a PR. Things I noticed with that:

1. It starts up fine, not complaining about finding the executable ✅
2. At the time to print it errors out saying it can't find the executable ❌

I believe `do_version` calls `executable()` without passing in the config options, so `chrome_executable` isn't being read.

```
** (RuntimeError) could not find executable from ["chromium-browser", "chromium", "chrome.exe", "google-chrome", "/usr/bin/chromium-browser", "/usr/bin/chromium", "/usr/bin/google-chrome", "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", "/Applications/Chromium.app/Contents/MacOS/Chromium"]
 web.1  |     (chromic_pdf 1.15.2) lib/chromic_pdf/pdf/chrome_runner.ex:84: ChromicPDF.ChromeRunner.executable/1
 web.1  | 
 web.1  |     (chromic_pdf 1.15.2) lib/chromic_pdf/utils.ex:127: ChromicPDF.Utils.with_app_config_cache/2
 web.1  |     (chromic_pdf 1.15.2) lib/chromic_pdf/pdf/chrome_runner.ex:35: ChromicPDF.ChromeRunner.do_version/0
 web.1  |     (chromic_pdf 1.15.2) lib/chromic_pdf/template.ex:368: ChromicPDF.Template.default_zoom/0
 web.1  |     (chromic_pdf 1.15.2) lib/chromic_pdf/template.ex:360: ChromicPDF.Template.assigns_for_styles/1
 web.1  |     (chromic_pdf 1.15.2) lib/chromic_pdf/template.ex:321: ChromicPDF.Template.page_styles/1
 web.1  |     (chromic_pdf 1.15.2) lib/chromic_pdf/template.ex:171: ChromicPDF.Template.source_and_options/1
```

-- but that's for another PR. This navigating took away 😅 Hope this helps!