### PR TITLE
Make ChromeRunner.version/0 optional in Template

### DIFF
--- a/lib/chromic_pdf/pdf/chrome_runner.ex
+++ b/lib/chromic_pdf/pdf/chrome_runner.ex
@@ -64,15 +64,14 @@ defmodule ChromicPDF.ChromeRunner do
   @default_executables [
     "chromium-browser",
     "chromium",
-    "chrome.exe",
     "google-chrome",
+    "chrome",
+    "chrome.exe",
     "/usr/bin/chromium-browser",
     "/usr/bin/chromium",
     "/usr/bin/google-chrome",
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    "chrome",
-    "chromedriver"
+    "/Applications/Chromium.app/Contents/MacOS/Chromium"
   ]
 
   defp executable(opts \\ []) do

--- a/lib/chromic_pdf/template.ex
+++ b/lib/chromic_pdf/template.ex
@@ -357,8 +357,8 @@ defmodule ChromicPDF.Template do
       header_font_size: Keyword.get(opts, :header_font_size, "10pt"),
       footer_height: Keyword.get(opts, :footer_height, "0"),
       footer_font_size: Keyword.get(opts, :footer_font_size, "10pt"),
-      header_zoom: Keyword.get(opts, :header_zoom, default_zoom()),
-      footer_zoom: Keyword.get(opts, :footer_zoom, default_zoom()),
+      header_zoom: Keyword.get_lazy(opts, :header_zoom, &default_zoom/0),
+      footer_zoom: Keyword.get_lazy(opts, :footer_zoom, &default_zoom/0),
       webkit_print_color_adjust: Keyword.get(opts, :webkit_print_color_adjust, "exact"),
       text_rendering: Keyword.get(opts, :text_rendering, "auto")
     ]


### PR DESCRIPTION
This makes the call to `ChromeRunner.version/0` optional in `Template` to allow people who use a non-standard `:chrome_executable` to also use the `Template` (by specifying the zoom explicitly). Unfortunately, taking the `:chrome_executable` into account is quite annoying in the template opts, so we may instead just want to document this better. Users can also set the application env key explicitly before running chromic.