### PR TITLE
Use `~c` in favor of single-quotes to create charlists

### DIFF
--- a/lib/chromic_pdf/pdf/connection/inet.ex
+++ b/lib/chromic_pdf/pdf/connection/inet.ex
@@ -58,7 +58,7 @@ if Code.ensure_loaded?(WebSockex) do
       :inets.start()
 
       url = String.to_charlist("http://#{host}:#{port}/json/version")
-      headers = [{'accept', 'application/json'}]
+      headers = [{~c"accept", ~c"application/json"}]
       http_request_opts = [ssl: [verify: :verify_none]]
 
       case :httpc.request(:get, {url, headers}, http_request_opts, []) do


### PR DESCRIPTION
Elixir 1.17 deprecated single-quotes to create charlists ([see changelog](https://github.com/elixir-lang/elixir/blob/ddf84aba7e60aae4541dee3b8225faff5b31cb32/CHANGELOG.md?plain=1#L189)). This project uses single-quotes in one place to create charlists, which this PR converts to `~c`.