### PR TITLE
Add ability to remove default args via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+- Extend `chrome_args` to allow removal of conflicting default args. Allows for use cases which were previously blocked by defaults such as rendering WebGL images. See #314 (@walter)
+
 ## [1.16.0] - 2024-06-25
 
 ### Changed

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -287,13 +287,16 @@ defmodule ChromicPDF do
   E.g. in default args within chromic_pdf's code, `--disable-gpu` and then
   passing `chrome_args: "--enable-gpu"` won't work.
 
-  The `:conflicting_args` option allows targeted removing of problematic default
-  args so that they don't disrupt your chrome configuration.
+  In this case, use Keyword form of the `:chrome_args` option which
+  allows targeted removing of problematic default args so that they don't
+  disrupt your chrome configuration.
 
       defp chromic_pdf_opts do
-        [conflicting_args: ["--headless", "--disable-gpu"],
-         chrome_args: "--headless=new --angle=swiftshader"]
+        [chrome_args: [append: "--headless=new --angle=swiftshader",
+                       remove: ["--headless", "--disable-gpu"]]]
       end
+
+  _Note: `:append` expects a string whereas `:remove` expects a list._
 
   The `:chrome_executable` option allows to specify a custom Chrome/Chromium executable.
 

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -296,8 +296,6 @@ defmodule ChromicPDF do
                        remove: ["--headless", "--disable-gpu"]]]
       end
 
-  _Note: `:append` expects a string whereas `:remove` expects a list._
-
   The `:chrome_executable` option allows to specify a custom Chrome/Chromium executable.
 
       defp chromic_pdf_opts do

--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -278,6 +278,23 @@ defmodule ChromicPDF do
         [chrome_args: "--font-render-hinting=none"]
       end
 
+  In some cases, chromic_pdf's default args may conflict with the ones you would like to add.
+
+  E.g. `--disable-gpu`
+
+  The problem is that you can't simply override them like so:
+
+  E.g. in default args within chromic_pdf's code, `--disable-gpu` and then
+  passing `chrome_args: "--enable-gpu"` won't work.
+
+  The `:conflicting_args` option allows targeted removing of problematic default
+  args so that they don't disrupt your chrome configuration.
+
+      defp chromic_pdf_opts do
+        [conflicting_args: ["--headless", "--disable-gpu"],
+         chrome_args: "--headless=new --angle=swiftshader"]
+      end
+
   The `:chrome_executable` option allows to specify a custom Chrome/Chromium executable.
 
       defp chromic_pdf_opts do

--- a/lib/chromic_pdf/pdf/chrome_runner.ex
+++ b/lib/chromic_pdf/pdf/chrome_runner.ex
@@ -147,9 +147,9 @@ defmodule ChromicPDF.ChromeRunner do
   # https://github.com/bitcrowd/chromic_pdf/issues/76
   defp args(extra, opts) do
     default_args()
-    |> remove_conflicting_args(opts)
+    |> remove_conflicting_args(opts[:chrome_args])
     |> append_if("--no-sandbox", no_sandbox?(opts))
-    |> append_if(to_string(opts[:chrome_args]), !!opts[:chrome_args])
+    |> append_chrome_args_if(opts[:chrome_args])
     |> Kernel.++(List.wrap(extra))
     |> append_if("2>/dev/null 3<&0 4>&1", discard_stderr?(opts))
   end
@@ -157,11 +157,27 @@ defmodule ChromicPDF.ChromeRunner do
   defp append_if(list, _value, false), do: list
   defp append_if(list, value, true), do: list ++ [value]
 
+  defp append_chrome_args_if(list, ""), do: list
+
+  defp append_chrome_args_if(list, chrome_args) when is_binary(chrome_args) do
+    append_if(list, chrome_args, true)
+  end
+
+  defp append_chrome_args_if(list, [{_, _} | _] = chrome_args) do
+    append = Keyword.get(chrome_args, :append)
+
+    append_if(list, append, !!append)
+  end
+
+  defp append_chrome_args_if(list, _), do: list
+
   defp no_sandbox?(opts), do: Keyword.get(opts, :no_sandbox, false)
   defp discard_stderr?(opts), do: Keyword.get(opts, :discard_stderr, true)
 
-  defp remove_conflicting_args(defaults, opts) do
-    conflicting_args = Keyword.get(opts, :conflicting_args, [])
-    Enum.reject(defaults, &Enum.member?(conflicting_args, &1))
+  defp remove_conflicting_args(defaults, [{_, _} | _] = chrome_args) do
+    conflicting = Keyword.get(chrome_args, :remove, [])
+    Enum.reject(defaults, &Enum.member?(conflicting, &1))
   end
+
+  defp remove_conflicting_args(defaults, _), do: defaults
 end

--- a/lib/chromic_pdf/pdf/chrome_runner.ex
+++ b/lib/chromic_pdf/pdf/chrome_runner.ex
@@ -147,6 +147,7 @@ defmodule ChromicPDF.ChromeRunner do
   # https://github.com/bitcrowd/chromic_pdf/issues/76
   defp args(extra, opts) do
     default_args()
+    |> remove_conflicting_args(opts)
     |> append_if("--no-sandbox", no_sandbox?(opts))
     |> append_if(to_string(opts[:chrome_args]), !!opts[:chrome_args])
     |> Kernel.++(List.wrap(extra))
@@ -158,4 +159,9 @@ defmodule ChromicPDF.ChromeRunner do
 
   defp no_sandbox?(opts), do: Keyword.get(opts, :no_sandbox, false)
   defp discard_stderr?(opts), do: Keyword.get(opts, :discard_stderr, true)
+
+  defp remove_conflicting_args(defaults, opts) do
+    conflicting_args = Keyword.get(opts, :conflicting_args, [])
+    Enum.reject(defaults, &Enum.member?(conflicting_args, &1))
+  end
 end

--- a/lib/chromic_pdf/pdf/connection/local.ex
+++ b/lib/chromic_pdf/pdf/connection/local.ex
@@ -17,13 +17,7 @@ defmodule ChromicPDF.Connection.Local do
   def handle_init(opts) do
     port =
       opts
-      |> Keyword.take([
-        :chrome_args,
-        :discard_stderr,
-        :no_sandbox,
-        :chrome_executable,
-        :conflicting_args
-      ])
+      |> Keyword.take([:chrome_args, :discard_stderr, :no_sandbox, :chrome_executable])
       |> ChromeRunner.port_open()
 
     Port.monitor(port)

--- a/lib/chromic_pdf/pdf/connection/local.ex
+++ b/lib/chromic_pdf/pdf/connection/local.ex
@@ -17,7 +17,13 @@ defmodule ChromicPDF.Connection.Local do
   def handle_init(opts) do
     port =
       opts
-      |> Keyword.take([:chrome_args, :discard_stderr, :no_sandbox, :chrome_executable])
+      |> Keyword.take([
+        :chrome_args,
+        :discard_stderr,
+        :no_sandbox,
+        :chrome_executable,
+        :conflicting_args
+      ])
       |> ChromeRunner.port_open()
 
     Port.monitor(port)

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -226,7 +226,7 @@ defmodule ChromicPDF.Supervisor do
       @type local_chrome_option ::
               {:no_sandbox, boolean()}
               | {:discard_stderr, boolean()}
-              | {:chrome_args, binary()}
+              | {:chrome_args, binary() | map()}
               | {:chrome_executable, binary()}
 
       @typedoc """

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -220,13 +220,17 @@ defmodule ChromicPDF.Supervisor do
 
       @type ghostscript_pool_option :: {:size, non_neg_integer()}
 
+      @type extended_chrome_args :: [
+              {:append, binary() | [binary()]} | {:remove, binary() | [binary()]}
+            ]
+
       @typedoc """
       These options apply to local Chrome instances only.
       """
       @type local_chrome_option ::
               {:no_sandbox, boolean()}
               | {:discard_stderr, boolean()}
-              | {:chrome_args, binary() | map()}
+              | {:chrome_args, binary() | extended_chrome_args()}
               | {:chrome_executable, binary()}
 
       @typedoc """


### PR DESCRIPTION
When trying to use chromic_pdf in combination with pages that contain WebGL images, there are two default args in `ChromeRunner` that prevent it from working.

* `--headless` (rather than `--headless=new`) 
* `--disable-gpu` which, despite its name, will disable software based webgl rendering in addition to hardware accelerated webgl

Based on my experimentation, simply overriding these in `:chrome_args` is not enough. Once they are declared, they can't be overridden by further switches.

Instead of just taking these out, and maybe break other people's projects, I think adding the ability to remove the args via configuration is a more  useful feature.
