### PR TITLE
Support custom protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 ## Unreleased
 
+### Changed
+
+- Some of the types have been renamed, e.g. `ChromicPDF.export_option` to `shared_option`.
+
 ### Fixed
 
 - Small fix `:chrome_version` config switch allowing to pass `Chrome x.y.z.zz` instead of just `x.y.z.zz`
+
+### Added
+
+- Support custom protocols through `:protocol` option on `print_to_pdf/2` and `capture_screenshot`, as well as new `ChromicPDF.run_protocol/2` function. These features are considered internal API.
 
 ## [1.16.1] - 2024-07-25
 

--- a/lib/chromic_pdf/pdf/browser/channel.ex
+++ b/lib/chromic_pdf/pdf/browser/channel.ex
@@ -93,6 +93,8 @@ defmodule ChromicPDF.Browser.Channel do
     :ok
   end
 
+  def terminate(_exception, _state), do: :ok
+
   defp warn_on_inspector_crash(msg) do
     if match?(%{"method" => "Inspector.targetCrashed"}, msg) do
       Logger.error("""

--- a/lib/chromic_pdf/pdf/protocol.ex
+++ b/lib/chromic_pdf/pdf/protocol.ex
@@ -19,8 +19,8 @@ defmodule ChromicPDF.Protocol do
   @type step :: call_step() | await_step() | output_step()
 
   # A protocol knows three types of steps: calls, awaits, and output.
-  # * The call step is a protocol call to send to the browser. Multiple call steps in sequence
-  #   are executed sequentially until the next await step is found.
+  # * The call step transforms the state and produces a protocol call to send to the browser.
+  #   Multiple call steps in sequence are executed sequentially until the next await step is found.
   # * Await steps are steps that try to match on messages received from the browser. When a
   #   message is matched, the await step can be removed from the queue (depending on the second
   #   element of the return tuple, `:keep | :remove`). Multiple await steps in sequence are

--- a/test/integration/custom_protocol_test.exs
+++ b/test/integration/custom_protocol_test.exs
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule ChromicPDF.CustomProtocolTest do
+  use ChromicPDF.Case, async: false
+  import ChromicPDF.TestAPI
+
+  defmodule BypassCSP do
+    import ChromicPDF.ProtocolMacros
+
+    steps do
+      call(:set_bypass_csp, "Page.setBypassCSP", [], %{"enabled" => true})
+      await_response(:bypass_csp_set, [])
+
+      include_protocol(ChromicPDF.PrintToPDF)
+    end
+  end
+
+  defmodule FixedScreenMetrics do
+    import ChromicPDF.ProtocolMacros
+
+    steps do
+      call(
+        :device_metrics,
+        "Emulation.setDeviceMetricsOverride",
+        [],
+        %{"width" => 200, "height" => 200, "mobile" => false, "deviceScaleFactor" => 1}
+      )
+
+      await_response(:device_metrics_response, [])
+
+      include_protocol(ChromicPDF.CaptureScreenshot)
+    end
+  end
+
+  defmodule GetUserAgent do
+    import ChromicPDF.ProtocolMacros
+
+    steps do
+      call(:get_version, "Browser.getVersion", [], %{})
+      await_response(:version, ["userAgent"])
+
+      output("userAgent")
+    end
+  end
+
+  setup do
+    start_supervised!(ChromicPDF)
+    :ok
+  end
+
+  describe ":protocol option to print_to_pdf/2" do
+    @html_with_csp """
+    <html>
+      <head>
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'">
+      </head>
+      <body>
+        <iframe src="data:text/html;charset=utf-8,%3Chtml%3E%3Cbody%3Efrom iframe%3C/body%3E%3C/html%3E">
+      </body>
+    </html>
+    """
+
+    @tag :pdftotext
+    test "allows to override the default protocol" do
+      print_to_pdf({:html, @html_with_csp}, fn text ->
+        refute String.contains?(text, "from iframe")
+      end)
+
+      print_to_pdf({:html, @html_with_csp}, [protocol: BypassCSP], fn text ->
+        assert String.contains?(text, "from iframe")
+      end)
+    end
+  end
+
+  describe ":protocol option to capture_screenshot/2" do
+    test "allows to set a custom protocol for capture_screenshot/2" do
+      assert {_, 200, 200} = capture_screenshot_and_identify(protocol: FixedScreenMetrics)
+    end
+  end
+
+  describe "run_protocol/2" do
+    test "allows to run custom protocols and get their output" do
+      assert {:ok, user_agent} = ChromicPDF.run_protocol(GetUserAgent)
+      assert user_agent =~ ~r/chrom/i
+    end
+  end
+end

--- a/test/integration/screenshot_test.exs
+++ b/test/integration/screenshot_test.exs
@@ -2,33 +2,11 @@
 
 defmodule ChromicPDF.ScreenshotTest do
   use ChromicPDF.Case, async: false
+  import ChromicPDF.TestAPI
   import ChromicPDF.Utils
   import ChromicPDF.ChromeRunner, only: [version: 0]
 
-  @test_html Path.expand("../fixtures/test.html", __ENV__.file)
   @large_html Path.expand("../fixtures/large.html", __ENV__.file)
-
-  defp capture_screenshot(opts \\ []) do
-    {source, opts} = Keyword.pop(opts, :source)
-
-    ChromicPDF.capture_screenshot(source || {:url, "file://#{@test_html}"}, opts)
-  end
-
-  defp capture_screenshot_and_identify(opts) do
-    with_tmp_dir(fn tmp_dir ->
-      img = "#{tmp_dir}/test"
-      :ok = capture_screenshot([{:output, img} | opts])
-
-      {stdout, 0} = System.cmd("identify", [img])
-
-      [_, format, dimensions | _] = String.split(stdout, " ")
-
-      %{"width" => width, "height" => height} =
-        Regex.named_captures(~r/^(?<width>\d+)x(?<height>\d+)$/, dimensions)
-
-      {format, String.to_integer(width), String.to_integer(height)}
-    end)
-  end
 
   describe "Taking screenshots" do
     setup do

--- a/test/integration/support/get_targets.ex
+++ b/test/integration/support/get_targets.ex
@@ -13,10 +13,7 @@ defmodule ChromicPDF.GetTargets do
   end
 
   def run do
-    {:ok, target_infos} =
-      ChromicPDF.Supervisor.with_services(ChromicPDF, fn services ->
-        ChromicPDF.Browser.new_protocol(services.browser, __MODULE__, skip_session_use_count: true)
-      end)
+    {:ok, target_infos} = ChromicPDF.run_protocol(__MODULE__, skip_session_use_count: true)
 
     for %{"targetId" => target_id, "url" => url} <- target_infos,
         String.ends_with?(url, "priv/blank.html"),


### PR DESCRIPTION
This patch makes the API more versatile by allowing to run custom protocols.

- add `:protocol` option to `print_to_pdf/2` & `capture_screenshot/2`
- refactor API & options handling around `chrome_export/2`
- add new top-level, but hidden `run_protocol/2` API

For the time being, these features are not advertised in the documentation. The `ChromicPDF.Protocol` machinery can be quite tricky and the poor DSL in `ChromicPDF.ProtocolMacros` is subject to change. Nonetheless, this could be a way to avoid adding further options to change and extend the default protocols' behaviour.

Relates to #319