### PR TITLE
Add new headless mode flag

### DIFF
--- a/lib/chromic_pdf.ex
+++ b/lib/chromic_pdf.ex
@@ -79,6 +79,16 @@ defmodule ChromicPDF do
   Note that this doesn't prevent other features like the `evaluate` option from working, it
   solely applies to scripts being supplied by the rendered page itself.
 
+  ### New vs Old Headless Mode
+
+  Chromic introduced a [new headless mode](https://developer.chrome.com/docs/chromium/new-headless) from version 112 onwards, but starts in the old mode by default.
+
+  You can enable the new headless mode with the option:
+
+      def chromid_pdf_opts do
+        [new_headless_mode: true]
+      end
+
   ### Running in offline mode
 
   To prevent your templates from accessing any remote hosts, the browser targets can be spawned

--- a/lib/chromic_pdf/pdf/chrome_runner.ex
+++ b/lib/chromic_pdf/pdf/chrome_runner.ex
@@ -116,7 +116,6 @@ defmodule ChromicPDF.ChromeRunner do
   # option (i.e. via pipes) instead of via a socket.
 
   @default_args [
-    "--headless",
     "--disable-accelerated-2d-canvas",
     "--disable-gpu",
     "--allow-pre-commit-input",
@@ -157,6 +156,7 @@ defmodule ChromicPDF.ChromeRunner do
   defp args(extra, opts) do
     default_args()
     |> append_if("--no-sandbox", no_sandbox?(opts))
+    |> append_if_else("--headless", "--headless=new", new_headless_mode?(opts))
     |> apply_chrome_args(opts[:chrome_args])
     |> Kernel.++(List.wrap(extra))
     |> append_if("2>/dev/null 3<&0 4>&1", discard_stderr?(opts))
@@ -164,6 +164,9 @@ defmodule ChromicPDF.ChromeRunner do
 
   defp append_if(list, _value, false), do: list
   defp append_if(list, value, true), do: append(list, value)
+
+  defp append_if_else(list, if_value, _else_value, true), do: append(list, if_value)
+  defp append_if_else(list, _if_value, else_value, false), do: append(list, else_value)
 
   defp append(list, value), do: list ++ List.wrap(value)
 
@@ -183,5 +186,6 @@ defmodule ChromicPDF.ChromeRunner do
   end
 
   defp no_sandbox?(opts), do: Keyword.get(opts, :no_sandbox, false)
+  defp new_headless_mode?(opts), do: Keyword.get(opts, :new_headless_mode, false)
   defp discard_stderr?(opts), do: Keyword.get(opts, :discard_stderr, true)
 end

--- a/lib/chromic_pdf/pdf/connection/local.ex
+++ b/lib/chromic_pdf/pdf/connection/local.ex
@@ -17,7 +17,7 @@ defmodule ChromicPDF.Connection.Local do
   def handle_init(opts) do
     port =
       opts
-      |> Keyword.take([:chrome_args, :discard_stderr, :no_sandbox, :chrome_executable])
+      |> Keyword.take([:chrome_args, :discard_stderr, :no_sandbox, :new_headless_mode, :chrome_executable])
       |> ChromeRunner.port_open()
 
     Port.monitor(port)

--- a/lib/chromic_pdf/pdf/protocol.ex
+++ b/lib/chromic_pdf/pdf/protocol.ex
@@ -160,6 +160,7 @@ defmodule ChromicPDF.Protocol do
         :session_pool => true,
         :no_sandbox => true,
         :discard_stderr => true,
+        :new_headless_mode => false,
         :chrome_args => true,
         :chrome_executable => true,
         :ignore_certificate_errors => true,

--- a/lib/chromic_pdf/supervisor.ex
+++ b/lib/chromic_pdf/supervisor.ex
@@ -232,6 +232,7 @@ defmodule ChromicPDF.Supervisor do
       @type local_chrome_option ::
               {:no_sandbox, boolean()}
               | {:discard_stderr, boolean()}
+              | {:new_headless_mode, boolean()}
               | {:chrome_args, binary() | extended_chrome_args()}
               | {:chrome_executable, binary()}
 

--- a/test/unit/chromic_pdf/pdf/protocol_test.exs
+++ b/test/unit/chromic_pdf/pdf/protocol_test.exs
@@ -42,6 +42,7 @@ defmodule ChromicPDF.ProtocolTest do
         session_pool: 1,
         no_sandbox: true,
         discard_stderr: true,
+        new_headless_mode: true,
         chrome_args: "some-args",
         chrome_executable: "chromium",
         ignore_certificate_errors: true,
@@ -67,6 +68,7 @@ defmodule ChromicPDF.ProtocolTest do
       assert inspected =~ ~s(:init_timeout => 1)
       assert inspected =~ ~s(:max_session_uses => 1)
       assert inspected =~ ~s(:no_sandbox => true)
+      assert inspected =~ ~s(:new_headless_mode => true)
       assert inspected =~ ~s(:offline => true)
       assert inspected =~ ~s(:on_demand => true)
       assert inspected =~ ~s(:output => "[FILTERED]")


### PR DESCRIPTION
Hey folks,

Chrome introduced a new headless mode with Chrome 112: https://developer.chrome.com/docs/chromium/new-headless

ChromicPDF currently uses the old headless mode because the flag `--headless` defaults to `--headless=old`. The problem is that we can't overwrite the default flag with `--headless=new` because the list of arguments would contain both flags and I'm unsure which flag is ignored.

So, I added a quick option, which enables the mode if set to `true`. Please let me know what you think about this and feel free to ignore this PR of course if you think it's unnecessary :)