### PR TITLE
#332 Fix exception message capture

### DIFF
--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -233,13 +233,7 @@ defmodule ChromicPDF.ProtocolMacros do
          true <- state["sessionId"] == msg["sessionId"] do
       exception = get_in!(msg, ["params", "exceptionDetails"])
       prefix = get_in(exception, ["text"])
-
-      suffix =
-        get_in(exception, ["exception", "description"])
-        |> case do
-          nil -> "undefined"
-          description -> description
-        end
+      suffix = get_in(exception, ["exception", "description"]) || "undefined"
 
       description = "#{prefix} #{suffix}"
 

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -233,7 +233,9 @@ defmodule ChromicPDF.ProtocolMacros do
          true <- state["sessionId"] == msg["sessionId"] do
       exception = get_in!(msg, ["params", "exceptionDetails"])
       prefix = get_in(exception, ["text"])
-      suffix = get_in(exception, ["exception", "description"])
+
+      suffix =
+        get_in(exception, ["exception", "description"])
         |> case do
           nil -> "undefined"
           description -> description

--- a/lib/chromic_pdf/pdf/protocol_macros.ex
+++ b/lib/chromic_pdf/pdf/protocol_macros.ex
@@ -232,7 +232,14 @@ defmodule ChromicPDF.ProtocolMacros do
     with true <- JsonRPC.notification?(msg, "Runtime.exceptionThrown"),
          true <- state["sessionId"] == msg["sessionId"] do
       exception = get_in!(msg, ["params", "exceptionDetails"])
-      description = get_in!(exception, ["exception", "description"])
+      prefix = get_in(exception, ["text"])
+      suffix = get_in(exception, ["exception", "description"])
+        |> case do
+          nil -> "undefined"
+          description -> description
+        end
+
+      description = "#{prefix} #{suffix}"
 
       case Map.get(state, :unhandled_runtime_exceptions, :log) do
         :ignore ->


### PR DESCRIPTION
Basically the main issue was when the description was missing. And it seems the description is missing when the passed error is `undefined`.

# Examples:

## Throw

** Script **
```js
throw(undefined);
```

** Javascript console output: **
```
index.js:14 Uncaught undefined
```

** Chromic displayed message: **
```
Uncaught undefined
```

## Promises
** Script **
```js
new Promise((_, reject) => reject())
```
** Javascript console output: **
```
index.js:15 Uncaught (in promise) undefined
```

** Chromic displayed message: **
```
Uncaught (in promise) undefined
```